### PR TITLE
Fix hidden deckBuilder zone labels

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/deckBuild.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/deckBuild.css
@@ -200,3 +200,12 @@ button.navigation-butt {
 .notesDialog {
     display: flex;
 }
+
+#missionsLabel,
+#seedDeckLabel,
+#drawDeckLabel {
+    z-index: 11;
+    position: absolute;
+    padding-left: 10px;
+    color: white;
+}

--- a/gemp-module/gemp-stccg-client/src/main/web/deckBuild.html
+++ b/gemp-module/gemp-stccg-client/src/main/web/deckBuild.html
@@ -69,14 +69,14 @@
 			</select>
 		</div>
 
-		<div id="missionsDiv">Missions</div>
-		<div id="seedDeckDiv">Seed Deck</div>
+		<div id="missionsDiv"><div id="missionsLabel">Missions</div></div>
+		<div id="seedDeckDiv"><div id="seedDeckLabel">Seed Deck</div></div>
 
 		<div id="statsDiv">
 			<div id="deckStats"></div>
 		</div>
 
-		<div id="decksRegion"></div>
+		<div id="decksRegion"><div id="drawDeckLabel">Draw Deck</div></div>
 	</div>
 
 	<div id="collectionDiv" class="ui-layout-east ui-layout-pane ui-layout-pane-east">

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -1070,15 +1070,15 @@ export class ST1EDeckBuildingUI extends GempLotrDeckBuildingUI {
             var seedDeckWidth = subDeckRight - seedDeckLeft;
             
             this.missionsDiv.css({ position:"absolute", left:padding, top:subDeckTop, width:missionsWidth,
-                height:deckRowHeight});
+                height:deckRowHeight, "z-index": 9});
             this.missionsGroup.setBounds(0, 0, missionsWidth, deckRowHeight);
 
             this.seedDeckDiv.css({ position:"absolute", left:seedDeckLeft, top:subDeckTop, width:seedDeckWidth,
-                height:deckRowHeight});
+                height:deckRowHeight, "z-index": 9});
             this.seedDeckGroup.setBounds(0, 0, seedDeckWidth, deckRowHeight);
 
             this.drawDeckDiv.css({ position:"absolute", left:padding, top:drawDeckTop, width:subDeckWidth,
-                height:deckRowHeight });
+                height:deckRowHeight, "z-index": 9 });
             this.drawDeckGroup.setBounds(0, 0, subDeckWidth, deckRowHeight);
 
         } else {


### PR DESCRIPTION
### Summary of Changes
Adds z-index levels to the various ST1E deckbuilder zones and makes the labels visible. Closes #22.

### Benefits
- You can tell where to drag the cards.

### Risks
- None.

### Testing
- Manual.

### Possible improvements to this PR
- Once you've dragged enough cards over, the labels fade into the UI. This is because the labels kind of float above the cards, they don't really have a dedicated location in the UI. I could improve this, but the effort to fix all the position:absolute bs the UI is pulling would take hours; this is a quick fix.

### Other notes
- None