### PR TITLE
Automatically run backend tests on pull request

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,25 @@
+name: Backend Tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+        cache: maven
+        cache-dependency-path: 'gemp-module/pom.xml'
+    - name: Run tests with Maven
+      run: mvn test --file gemp-module/pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    # - name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,7 +18,7 @@ jobs:
         cache: maven
         cache-dependency-path: 'gemp-module/pom.xml'
     - name: Run tests with Maven
-      run: mvn test -X --file gemp-module/pom.xml
+      run: mvn test --file gemp-module/pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,7 +18,7 @@ jobs:
         cache: maven
         cache-dependency-path: 'gemp-module/pom.xml'
     - name: Run tests with Maven
-      run: mvn test --file gemp-module/pom.xml
+      run: mvn test -X --file gemp-module/pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/gemp-module/gemp-stccg-common/pom.xml
+++ b/gemp-module/gemp-stccg-common/pom.xml
@@ -21,12 +21,6 @@
             <version>2.20.0</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.2.0</version>

--- a/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
+++ b/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
@@ -10,7 +10,7 @@ db.connection.validateQuery=/* ping */ select 1
 
 port=80
 web.path=/etc/gemp-module/web/
-resources.path=/etc/gemp-module/gemp-stccg-cards/src/main/resources/
+resources.path=../gemp-stccg-cards/src/main/resources/
 dev.resources.path=../gemp-stccg-cards/src/main/resources/
 test.resources.path=../gemp-stccg-cards/src/main/resources/
 

--- a/gemp-module/gemp-stccg-logic/pom.xml
+++ b/gemp-module/gemp-stccg-logic/pom.xml
@@ -40,12 +40,15 @@
             <artifactId>hjson</artifactId>
             <version>3.1.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/java/com/gempukku/stccg/</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
 </project>

--- a/gemp-module/gemp-stccg-server/pom.xml
+++ b/gemp-module/gemp-stccg-server/pom.xml
@@ -72,12 +72,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.9.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.7.0</version>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -23,6 +23,33 @@
         <java.version>21</java.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+            <version>5.11.1</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -68,6 +68,11 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -48,6 +48,12 @@
             <version>5.11.1</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.11.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Summary of Changes
Adds an automated script that runs all backend unit tests via `mvn test` any time a Pull Request is opened.

### Benefits
- Provides another set of automated eyes to catch potential logic errors from the backend.
- Catches cases where team members did not run `mvn test`, ignored tests, or otherwise did not test the backend on their branch.

### Risks
- Could rack up a bill; we have 2000 minutes/month of runtime, I think that will be more than enough. Mitigated by the fact that the GH Docs imply that since we're on a free account, we will not be charged. Instead, the automation will fail to run if we go over.
- Does not catch cases where people delete or intentionally skip unit tests. Risk known and accepted.

Testing
- Manual. Ironic.

### Possible improvements to this PR
- We could have it run `mvn build` and verify that it builds OK. I think that is a waste of automation minutes at this time since we're doing that locally as part of our dev workflows.
- We could have it run `docker compose --build` and verify that the docker containers build OK. I think that is a waste of automation minutes at this time, since we're doing that locally as part of our dev workflows.

### Other notes
- Automated front end testing will be added in a separate PR.