### PR TITLE
Back-end game loop tests

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,25 @@
+name: Backend Tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+        cache: maven
+        cache-dependency-path: 'gemp-module/pom.xml'
+    - name: Run tests with Maven
+      run: mvn test --file gemp-module/pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    # - name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,7 +18,7 @@ jobs:
         cache: maven
         cache-dependency-path: 'gemp-module/pom.xml'
     - name: Run tests with Maven
-      run: mvn test -X --file gemp-module/pom.xml
+      run: mvn test --file gemp-module/pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,7 +18,7 @@ jobs:
         cache: maven
         cache-dependency-path: 'gemp-module/pom.xml'
     - name: Run tests with Maven
-      run: mvn test --file gemp-module/pom.xml
+      run: mvn test -X --file gemp-module/pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set101.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set101.hjson
@@ -1113,6 +1113,69 @@
         cunning: 5
         strength: 9
         image-url: https://www.trekcc.org/1e/cardimages/tngsup/30V.jpg
+        rarity: R
+    }
+    101_269: {
+        title: Kell
+        type: personnel
+        affiliation: klingon
+        property-logo: tng-logo
+        classification: V.I.P.
+        lore: Male High Council emissary. Covert Romulan agent. Attempted to use Lt. Commander Geordi La Forge to assassinate Klingon Governor Vagh.
+        skill-box: "[*] Treachery"
+        integrity: 2
+        cunning: 6
+        strength: 5
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/kell95.jpg
+        rarity: U
+    }
+    101_270: {
+        title: Klag
+        type: personnel
+        uniqueness: universal
+        affiliation: klingon
+        property-logo: tng-logo
+        classification: OFFICER
+        icons: command
+        lore: Second Officer Klag, of the <i>I.K.C. Pagh</i>, is representative of Klingon warriors throughout the Klingon Empire.
+        skill-box: "[*] Navigation"
+        integrity: 6
+        cunning: 5
+        strength: 7
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/klag95.jpg
+        rarity: C
+    }
+    101_271: {
+        title: "Kle'eg"
+        type: personnel
+        uniqueness: universal
+        affiliation: klingon
+        property-logo: tng-logo
+        classification: SECURITY
+        icons: staff
+        lore: "Klingon trained in the specific field of security. Guarded the House of K'mpec when K'mpec was poisoned in 2367."
+        skill-box: "[*] Honor"
+        integrity: 6
+        cunning: 4
+        strength: 7
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/kleeg95.jpg
+        rarity: C
+    }
+    101_276: {
+        title: Kromm
+        type: personnel
+        affiliation: klingon
+        uniqueness: universal
+        property-logo: tng-logo
+        classification: ENGINEER
+        icons: staff
+        lore: Klingon trained in the field of engineering. Reputed to have consumed fifteen rokeg blood pies at one sitting.
+        skill-box: "[*] Physics"
+        integrity: 5
+        cunning: 6
+        strength: 8
+        image-url: https://www.trekcc.org/1e/cardimages/twtstarters/kromm.jpg
+        rarity: C
     }
     101_277: {
         title: Kurak
@@ -1140,6 +1203,22 @@
         cunning: 4
         strength: 7
         image-url: https://www.trekcc.org/1e/cardimages/premiere/torak95.jpg
+    }
+    101_286: {
+        title: Torin
+        type: personnel
+        affiliation: klingon
+        uniqueness: universal
+        property-logo: tng-logo
+        classification: SCIENCE
+        icons: staff
+        lore: Klingon trained in the field of science. Studied the effects of warp propulsion on subspace.
+        skill-box: "[*] Astrophysics"
+        integrity: 7
+        cunning: 6
+        strength: 6
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/torin95.jpg
+        rarity: C
     }
     101_288: {
         title: Vekma
@@ -1241,6 +1320,22 @@
         cunning: 8
         strength: 7
         image-url: https://www.trekcc.org/1e/cardimages/tngsup/34V.jpg
+    }
+    101_300: {
+        title: Narik
+        type: personnel
+        affiliation: non-aligned
+        uniqueness: universal
+        property-logo: tng-logo
+        classification: ENGINEER
+        icons: staff
+        lore: Representative of male mercenaries operating throughout the galaxy. Worked with Baran to find the Stone of Gol.
+        skill-box: "[*] Computer Skill"
+        integrity: 2
+        cunning: 7
+        strength: 6
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/narik95.jpg
+        rarity: C
     }
     101_303: {
         title: Vekor

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set101.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set101.hjson
@@ -686,6 +686,22 @@
         image-url: https://www.trekcc.org/1e/cardimages/premiere/leahbrahms95.jpg
         rarity: U
     }
+    101_220: {
+        title: Linda Larson
+        type: personnel
+        uniqueness: universal
+        affiliation: federation
+        property-logo: tng-logo
+        classification: ENGINEER
+        icons: staff
+        lore: Lieutenant Linda Larson is representative of staff engineers serving in Starfleet.
+        skill-box: "[*] Youth"
+        integrity: 7
+        cunning: 5
+        strength: 4
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/lindalarson95.jpg
+        rarity: C
+    }
     101_221: {
         title: Lwaxana Troi
         type: personnel
@@ -715,6 +731,22 @@
         strength: 3
         image-url: https://www.trekcc.org/1e/cardimages/premiere/mcknight95.jpg
         rarity: U
+    }
+    101_223: {
+        title: Mendon
+        type: personnel
+        affiliation: federation
+        property-logo: tng-logo
+        classification: SCIENCE
+        icons: staff
+        uniqueness: universal
+        lore: Ensign Mendon is a Benzite male representative of science specialists within Starfleet. Served aboard the <i>U.S.S. Enterprise</i> in 2365. Looks like Mordock.
+        skill-box: "[*] Physics"
+        integrity: 7
+        cunning: 5
+        strength: 2
+        image-url: https://www.trekcc.org/1e/cardimages/errata/Mendon.jpg
+        rarity: C
     }
     101_225: {
         title: Mot the Barber
@@ -942,6 +974,22 @@
         cunning: 6
         strength: 4
         image-url: https://www.trekcc.org/1e/cardimages/premiere/bael95.jpg
+        rarity: U
+    }
+    101_254: {
+        title: Batrell
+        type: personnel
+        affiliation: klingon
+        uniqueness: universal
+        property-logo: tng-logo
+        classification: OFFICER
+        icons: command
+        lore: Klingon trained as an officer for the Klingon Defense Force. Formerly in command of Narendra III outpost.
+        skill-box: "[*] Honor"
+        integrity: 7
+        cunning: 3
+        strength: 7
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/batrell95.jpg
     }
     101_256: {
         title: Divok
@@ -1149,6 +1197,22 @@
         cunning: 9
         strength: 3
         image-url: https://www.trekcc.org/1e/cardimages/twtstarters/devinoniral.jpg
+    }
+    101_293: {
+        title: Dr. Farek
+        type: personnel
+        affiliation: non-aligned
+        property-logo: tng-logo
+        classification: MEDICAL
+        uniqueness: universal
+        icons: command
+        lore: "Dr. Farek is representative of male Ferengi trained in medicine. Seized control of the <i>D'Kora</i> class Ferengi Marauder, <i>Krayton</i>, in 2366."
+        skill-box: "[*] Greed"
+        integrity: 2
+        cunning: 8
+        strength: 3
+        image-url: https://www.trekcc.org/1e/cardimages/premiere/drfarek95.jpg
+        rarity: C
     }
     101_297: {
         title: Gorta

--- a/gemp-module/gemp-stccg-common/pom.xml
+++ b/gemp-module/gemp-stccg-common/pom.xml
@@ -21,12 +21,6 @@
             <version>2.20.0</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.2.0</version>

--- a/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
+++ b/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
@@ -10,7 +10,7 @@ db.connection.validateQuery=/* ping */ select 1
 
 port=80
 web.path=/etc/gemp-module/web/
-resources.path=/etc/gemp-module/gemp-stccg-cards/src/main/resources/
+resources.path=../gemp-stccg-cards/src/main/resources/
 dev.resources.path=../gemp-stccg-cards/src/main/resources/
 test.resources.path=../gemp-stccg-cards/src/main/resources/
 

--- a/gemp-module/gemp-stccg-logic/pom.xml
+++ b/gemp-module/gemp-stccg-logic/pom.xml
@@ -40,12 +40,15 @@
             <artifactId>hjson</artifactId>
             <version>3.1.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/java/com/gempukku/stccg/</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
 </project>

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractAtTest extends AbstractLogicTest {
         // Taurik
         fedDeck.addCard(SubDeck.DRAW_DECK, "101_293"); // Dr. Farek
         fedDeck.addCard(SubDeck.DRAW_DECK, "101_297"); // Gorta
-        // Narik
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_300"); // Narik
         fedDeck.addCard(SubDeck.DRAW_DECK, "101_303"); // Vekor
         fedDeck.addCard(SubDeck.DRAW_DECK, "101_331"); // Runabout
         fedDeck.addCard(SubDeck.DRAW_DECK, "101_332"); // Type VI Shuttlecraft
@@ -125,16 +125,18 @@ public abstract class AbstractAtTest extends AbstractLogicTest {
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_260"); // Gorath
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_262"); // J'Ddan
         // K'Tesh x2
-        // Klag
-        // Kle'eg x2
-        // Kromm
-        // Torin x2
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_270"); // Klag
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_271"); // Kle'eg
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_271"); // Kle'eg
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_276"); // Kromm
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_286"); // Torin
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_286"); // Torin
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_288"); // Vekma
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_293"); // Dr. Farek
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_297"); // Gorta
-        // Narik
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_300"); // Narik
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_303"); // Vekor
-        // I.K.C. K'Ratak
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "103_118"); // I.K.C. K'Ratak
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort
         klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
@@ -11,6 +11,7 @@ import com.gempukku.stccg.common.filterable.Zone;
 import com.gempukku.stccg.decisions.CardActionSelectionDecision;
 import com.gempukku.stccg.formats.FormatLibrary;
 import com.gempukku.stccg.game.ST1EGame;
+import com.gempukku.stccg.game.TribblesGame;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
@@ -18,9 +19,11 @@ import java.util.*;
 public abstract class AbstractAtTest extends AbstractLogicTest {
 
     protected ST1EGame _game;
+    protected TribblesGame _tribblesGame;
     protected UserFeedback _userFeedback;
     public static final String P1 = "player1";
     public static final String P2 = "player2";
+    FormatLibrary formatLibrary = new FormatLibrary(_cardLibrary);
 
     protected void initializeSimple1EGame(int deckSize) {
         Map<String, CardDeck> decks = new HashMap<>();
@@ -32,12 +35,29 @@ public abstract class AbstractAtTest extends AbstractLogicTest {
         decks.put(P1, testDeck);
         decks.put(P2, testDeck);
 
-        FormatLibrary formatLibrary = new FormatLibrary(_cardLibrary);
         GameFormat format = formatLibrary.getFormat("st1emoderncomplete");
 
         _game = new ST1EGame(format, decks, _cardLibrary);
         _userFeedback = _game.getUserFeedback();
         _game.startGame();
+
+    }
+
+    protected void initializeSimpleTribblesGame(int deckSize) {
+        Map<String, CardDeck> decks = new HashMap<>();
+        CardDeck testDeck = new CardDeck("Test");
+        for (int i = 0; i < deckSize; i++) {
+            testDeck.addCard(SubDeck.DRAW_DECK, "221_002"); // 1 Tribble - Kindness
+        }
+
+        decks.put(P1, testDeck);
+        decks.put(P2, testDeck);
+
+        GameFormat format = formatLibrary.getFormat("tribbles");
+
+        _tribblesGame = new TribblesGame(format, decks, _cardLibrary);
+        _userFeedback = _tribblesGame.getUserFeedback();
+        _tribblesGame.startGame();
 
     }
 

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/AbstractAtTest.java
@@ -3,20 +3,14 @@ package com.gempukku.stccg;
 import com.gempukku.stccg.actions.Action;
 import com.gempukku.stccg.actions.Effect;
 import com.gempukku.stccg.actions.turn.SystemQueueAction;
-import com.gempukku.stccg.common.CardDeck;
-import com.gempukku.stccg.cards.CardNotFoundException;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCardGeneric;
-import com.gempukku.stccg.common.AwaitingDecision;
-import com.gempukku.stccg.common.DecisionResultInvalidException;
-import com.gempukku.stccg.common.UserFeedback;
+import com.gempukku.stccg.common.*;
 import com.gempukku.stccg.common.filterable.SubDeck;
 import com.gempukku.stccg.common.filterable.Zone;
 import com.gempukku.stccg.decisions.CardActionSelectionDecision;
 import com.gempukku.stccg.formats.FormatLibrary;
-import com.gempukku.stccg.common.GameFormat;
 import com.gempukku.stccg.game.ST1EGame;
-import com.gempukku.stccg.gamestate.DefaultUserFeedback;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
@@ -27,10 +21,6 @@ public abstract class AbstractAtTest extends AbstractLogicTest {
     protected UserFeedback _userFeedback;
     public static final String P1 = "player1";
     public static final String P2 = "player2";
-
-    protected PhysicalCardGeneric createCard(String owner, String blueprintId) throws CardNotFoundException {
-        return (PhysicalCardGeneric) _game.getGameState().createPhysicalCard(owner, _cardLibrary, blueprintId);
-    }
 
     protected void initializeSimple1EGame(int deckSize) {
         Map<String, CardDeck> decks = new HashMap<>();
@@ -51,29 +41,98 @@ public abstract class AbstractAtTest extends AbstractLogicTest {
 
     }
 
-    protected void initializeGameWithDecks(Map<String, CardDeck> decks) throws DecisionResultInvalidException {
-        _userFeedback = new DefaultUserFeedback();
+    protected void initializeIntroductoryTwoPlayerGame() {
+        Map<String, CardDeck> decks = new HashMap<>();
+
+        CardDeck fedDeck = new CardDeck("Federation");
+        fedDeck.addCard(SubDeck.MISSIONS, "106_004"); // Cargo Rendezvous
+        fedDeck.addCard(SubDeck.MISSIONS, "106_005"); // Distress Mission
+        fedDeck.addCard(SubDeck.MISSIONS, "106_007"); // Gravesworld
+        fedDeck.addCard(SubDeck.MISSIONS, "106_008"); // Homeward
+        fedDeck.addCard(SubDeck.MISSIONS, "106_009"); // Hostage Situation
+        fedDeck.addCard(SubDeck.MISSIONS, "106_013"); // Survey Instability
+        fedDeck.addCard(SubDeck.SEED_DECK, "101_104"); // Federation Outpost
+        // Dilemmas, Events & Interrupts
+        // Engineering Kit
+        // Medical Kit
+        // Medical Tricorder
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_065"); // Tricorder
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_201"); // Calloway
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_202"); // Christopher Hobson
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_202"); // Christopher Hobson
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_203"); // Darian Wallace
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_203"); // Darian Wallace
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_213"); // Giusti
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_220"); // Linda Larson
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_222"); // McKnight
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_223"); // Mendon
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_223"); // Mendon
+        fedDeck.addCard(SubDeck.DRAW_DECK, "103_096"); // Montgomery Scott
+        // Simon Tarses
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_236"); // Sito Jaxa
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_242"); // Taitt
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_242"); // Taitt
+        // Taurik
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_293"); // Dr. Farek
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_297"); // Gorta
+        // Narik
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_303"); // Vekor
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_331"); // Runabout
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_332"); // Type VI Shuttlecraft
+        // U.S.S. Galaxy x2
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_339"); // U.S.S. Nebula
+        fedDeck.addCard(SubDeck.DRAW_DECK, "101_339"); // U.S.S. Nebula
+
+
+        CardDeck klingonDeck = new CardDeck("Klingon");
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_002"); // A Good Place to Die
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_003"); // Avert Danger
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_006"); // Gault
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_010"); // Reopen Dig
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_011"); // Reported Activity
+        klingonDeck.addCard(SubDeck.MISSIONS, "106_012"); // Sensitive Search
+        klingonDeck.addCard(SubDeck.SEED_DECK, "101_105"); // Klingon Outpost
+        // Dilemmas, Events & Interrupts
+        // Engineering Kit
+        // Medical Kit
+        // Medical Tricorder
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_065"); // Tricorder
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_253"); // B'iJik
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_254"); // Batrell
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_256"); // Divok
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_256"); // Divok
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_257"); // Dukath
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_260"); // Gorath
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_262"); // J'Ddan
+        // K'Tesh x2
+        // Klag
+        // Kle'eg x2
+        // Kromm
+        // Torin x2
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_288"); // Vekma
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_293"); // Dr. Farek
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_297"); // Gorta
+        // Narik
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_303"); // Vekor
+        // I.K.C. K'Ratak
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_347"); // I.K.S. K'Vort
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_350"); // I.K.C. Vor'Cha
+        klingonDeck.addCard(SubDeck.DRAW_DECK, "101_350"); // I.K.C. Vor'Cha
+
+        decks.put(P1, fedDeck);
+        decks.put(P2, klingonDeck);
 
         FormatLibrary formatLibrary = new FormatLibrary(_cardLibrary);
-        GameFormat format = formatLibrary.getFormat("multipath");
+        GameFormat format = formatLibrary.getFormat("st1emoderncomplete");
 
-        _game = new ST1EGame(format, new HashMap<>(decks), _cardLibrary);
+        _game = new ST1EGame(format, decks, _cardLibrary);
         _userFeedback = _game.getUserFeedback();
         _game.startGame();
 
-        // Bidding
-        playerDecided(P1, "1");
-        playerDecided(P2, "0");
-
-        // Seating choice
-        playerDecided(P1, "0");
     }
 
-    protected void skipMulligans() throws DecisionResultInvalidException {
-        // Mulligans
-        playerDecided(P1, "0");
-        playerDecided(P2, "0");
-    }
 
     protected void validateContents(String[] array1, String[] array2) {
         if (array1.length != array2.length)

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/CreateGameTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/CreateGameTest.java
@@ -1,0 +1,41 @@
+package com.gempukku.stccg;
+
+import com.gempukku.stccg.common.DecisionResultInvalidException;
+import com.gempukku.stccg.common.filterable.Phase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CreateGameTest extends AbstractAtTest {
+
+    @Test
+    public void introTwoPlayerGameTest() throws DecisionResultInvalidException {
+        initializeIntroductoryTwoPlayerGame();
+
+        // Figure out which player is going first
+        String player1 = _game.getGameState().getPlayerOrder().getFirstPlayer();
+        String player2 = _game.getOpponent(player1);
+
+        // The game should start in the mission seed phase, with only the first player having an awaiting decision
+        assertNotNull(_userFeedback.getAwaitingDecision(player1));
+        assertNull(_userFeedback.getAwaitingDecision(player2));
+        assertEquals(Phase.SEED_MISSION, _game.getGameState().getCurrentPhase());
+
+        playerDecided(player1, "0"); // This should seed the first mission, then seeding should advance to player2
+
+        assertNotNull(_userFeedback.getAwaitingDecision(player2));
+        assertNull(_userFeedback.getAwaitingDecision(player1));
+        assertEquals(Phase.SEED_MISSION, _game.getGameState().getCurrentPhase());
+        assertEquals(1, _game.getGameState().getSpacelineLocations().size());
+
+        // Player2 will need to decide twice - once to select the mission, then once to decide where to seed it
+        playerDecided(player2, "0");
+        assertNotNull(_userFeedback.getAwaitingDecision(player2));
+        playerDecided(player2, "0");
+
+        assertNotNull(_userFeedback.getAwaitingDecision(player1));
+        assertNull(_userFeedback.getAwaitingDecision(player2));
+        assertEquals(Phase.SEED_MISSION, _game.getGameState().getCurrentPhase());
+        assertEquals(2, _game.getGameState().getSpacelineLocations().size());
+    }
+
+}

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/CreateGameTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/CreateGameTest.java
@@ -38,4 +38,14 @@ public class CreateGameTest extends AbstractAtTest {
         assertEquals(2, _game.getGameState().getSpacelineLocations().size());
     }
 
+    @Test
+    public void tribblesGameTest() {
+        initializeSimpleTribblesGame(40);
+
+        String player1 = _tribblesGame.getGameState().getPlayerOrder().getFirstPlayer();
+
+        assertNotNull(_userFeedback.getAwaitingDecision(player1));
+
+    }
+
 }

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SeedPhaseTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SeedPhaseTest.java
@@ -1,0 +1,78 @@
+package com.gempukku.stccg;
+
+import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
+import com.gempukku.stccg.common.AwaitingDecisionType;
+import com.gempukku.stccg.common.DecisionResultInvalidException;
+import com.gempukku.stccg.common.filterable.CardType;
+import com.gempukku.stccg.common.filterable.Phase;
+import com.gempukku.stccg.filters.Filters;
+import com.gempukku.stccg.gamestate.ST1ELocation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SeedPhaseTest extends AbstractAtTest {
+
+    @Test
+    public void autoSeedTest() throws DecisionResultInvalidException {
+        initializeIntroductoryTwoPlayerGame();
+
+        // Figure out which player is going first
+        String player1 = _game.getGameState().getPlayerOrder().getFirstPlayer();
+        String player2 = _game.getOpponent(player1);
+
+        // Both players keep picking option #1 until all missions are seeded
+        while (_game.getGameState().getCurrentPhase() == Phase.SEED_MISSION) {
+            if (_userFeedback.getAwaitingDecision(player1) != null) {
+                playerDecided(player1, "0");
+            }
+            if (_userFeedback.getAwaitingDecision(player2) != null) {
+                playerDecided(player2, "0");
+            }
+        }
+
+        // There should now be 12 missions seeded
+        assertEquals(12, _game.getGameState().getSpacelineLocations().size());
+        for (ST1ELocation location : _game.getGameState().getSpacelineLocations()) {
+            System.out.println((location.getLocationZoneIndex()+1) + " - " + location.getLocationName());
+        }
+
+        // Both players seed facility at random eligible location
+        while (_game.getGameState().getCurrentPhase() == Phase.SEED_FACILITY) {
+            if (_userFeedback.getAwaitingDecision(player1) != null) {
+                if (_userFeedback.getAwaitingDecision(player1).getDecisionType() == AwaitingDecisionType.CARD_SELECTION) {
+                    List<String> cardIdList = new java.util.ArrayList<>(Arrays.stream(_userFeedback.getAwaitingDecision(player1).getDecisionParameters().get("cardId")).toList());
+                    Collections.shuffle(cardIdList);
+                    playerDecided(player1, cardIdList.getFirst());
+                }
+                else
+                    playerDecided(player1, "0");
+            }
+            if (_userFeedback.getAwaitingDecision(player2) != null) {
+                if (_userFeedback.getAwaitingDecision(player2).getDecisionType() == AwaitingDecisionType.CARD_SELECTION) {
+                    List<String> cardIdList = new java.util.ArrayList<>(Arrays.stream(_userFeedback.getAwaitingDecision(player2).getDecisionParameters().get("cardId")).toList());
+                    Collections.shuffle(cardIdList);
+                    playerDecided(player2, cardIdList.getFirst());
+                }
+                else
+                    playerDecided(player2, "0");
+            }
+        }
+
+        // Verify that both facilities were seeded
+        assertEquals(2, Filters.filterActive(_game, CardType.FACILITY).size());
+        for (PhysicalCard card : Filters.filterActive(_game, CardType.FACILITY)) {
+            System.out.println(card.getTitle() + " seeded at " + card.getLocation().getLocationName());
+        }
+
+        // Verify that the seed phase is over and both players have drawn starting hands
+        assertEquals(Phase.CARD_PLAY, _game.getGameState().getCurrentPhase());
+        assertEquals(7, _game.getGameState().getHand(player1).size());
+        assertEquals(7, _game.getGameState().getHand(player2).size());
+    }
+
+}

--- a/gemp-module/gemp-stccg-server/pom.xml
+++ b/gemp-module/gemp-stccg-server/pom.xml
@@ -72,12 +72,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.9.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.7.0</version>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -23,6 +23,33 @@
         <java.version>21</java.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+            <version>5.11.1</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -68,6 +68,11 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/gemp-module/pom.xml
+++ b/gemp-module/pom.xml
@@ -48,6 +48,12 @@
             <version>5.11.1</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.11.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Summary of Changes
Added a couple tests for the game loop, specifically focusing on 1E seed phase. Also added some 1E Premiere card definitions to flesh out the cardlist for the Introductory Two-Player Game, to use in testing. This branch also included merged code from Andrew's recent pull requests.

### Benefits
- Additional testing to improve confidence that code is working correctly.
- Framework to create game loop in back-end tests that can be adapted for future tests.

### Risks
None that I'm aware of.

### Testing
All tests passed locally, including the new ones.

### Possible improvements to this PR
Additional tests will be created in future updates.