### PR TITLE
Updates for gemp-stccg.properties

### DIFF
--- a/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/AppConfig.java
+++ b/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/AppConfig.java
@@ -74,6 +74,7 @@ public class AppConfig {
     }
 
     public static String getWebPath() { return getProperty("web.path"); }
+    public static File getReplayPath() { return new File(getProperty("replay.path")); }
     public static File getCardsPath() { return getResourceFile("cards"); }
     public static File getMappingsPath() { return getResourceFile("blueprintMapping.txt"); }
     public static File getSetDefinitionsPath() { return getResourceFile("setConfig.hjson"); }
@@ -81,5 +82,7 @@ public class AppConfig {
     public static File getProductPath() { return getResourceFile("product"); }
     public static File getSealedPath() { return getResourceFile("sealed"); }
     public static File getDraftPath() { return getResourceFile("draft"); }
+    public static String getPlaytestUrl() { return getProperty("playtest.url"); }
+    public static String getPlaytestPrefixUrl() { return getProperty("playtest.prefix.url"); }
 
 }

--- a/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
+++ b/gemp-module/gemp-stccg-common/src/main/resources/gemp-stccg.properties
@@ -1,5 +1,8 @@
-## Application root, used for example for storing replay files 
-application.root=/etc/gemp-module
+## httpPort used to initialize server
+port=80
+
+## Pattern to allow connections. This should be updated in production to match hostname DNS.
+origin.allowed.pattern=^.*$
 
 ## DB connection
 db.connection.class=com.mysql.cj.jdbc.Driver
@@ -8,10 +11,21 @@ db.connection.username=gempuser
 db.connection.password=gemppassword
 db.connection.validateQuery=/* ping */ select 1
 
-port=80
+## Path replay data is saved in
+replay.path=/etc/gemp-module/replay/
+
+## Path for web requests
 web.path=/etc/gemp-module/web/
-resources.path=../gemp-stccg-cards/src/main/resources/
+
+## Resources path used by Docker. The /etc/gemp_module part is necessary
+resources.path=/etc/gemp-module/gemp-stccg-cards/src/main/resources/
+
+## Resources path used by idea_rt.jar in IDE
 dev.resources.path=../gemp-stccg-cards/src/main/resources/
+
+## Resources path used by unit tests
 test.resources.path=../gemp-stccg-cards/src/main/resources/
 
-origin.allowed.pattern=^.*$
+## URLs used to create playtesting form in GameRecorder
+playtest.url=https://docs.google.com/forms/d/e/1FAIpQLSdKJrCmjoyUqDTusDcpNoWAmvkGdzQqTxWGpdNIFX9biCee-A/viewform?usp=pp_url&entry.1592109986=
+playtest.prefix.url=https://play.lotrtcgpc.net/gemp-lotr/game.html%3FreplayId%3D

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/game/GameRecorder.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/game/GameRecorder.java
@@ -98,11 +98,13 @@ public class GameRecorder {
 
             if(format.isPlaytest())
             {
-                String url = "https://docs.google.com/forms/d/e/1FAIpQLSdKJrCmjoyUqDTusDcpNoWAmvkGdzQqTxWGpdNIFX9biCee-A/viewform?usp=pp_url&entry.1592109986=";
-                String winnerURL = "https://play.lotrtcgpc.net/gemp-lotr/game.html%3FreplayId%3D" + winnerName + "$" + playerRecordingId.get(winnerName);
-                String loserURL = "https://play.lotrtcgpc.net/gemp-lotr/game.html%3FreplayId%3D" + loserName + "$" + playerRecordingId.get(loserName);
-                url += winnerURL + "%20" + loserURL;
-                game.sendMessageToPlayers("Thank you for playtesting!  If you have any feedback, bugs, or other issues to report about this match, <a href= '" + url + "'>please do so using this form.</a>");
+                String url = AppConfig.getPlaytestUrl() +
+                        AppConfig.getPlaytestPrefixUrl() + winnerName + "$" + playerRecordingId.get(winnerName) + "%20" +
+                        AppConfig.getPlaytestPrefixUrl() + loserName + "$" + playerRecordingId.get(loserName);
+                String message = "Thank you for playtesting!  " +
+                        "If you have any feedback, bugs, or other issues to report about this match, <a href= '" +
+                        url + "'>please do so using this form.</a>";
+                game.sendMessageToPlayers(message);
             }
 
         };
@@ -113,28 +115,25 @@ public class GameRecorder {
     }
 
     private File getRecordingFileVersion0(String playerId, String gameId) {
-        File gameReplayFolder = new File(AppConfig.getProperty("application.root"), "replay");
-        File playerReplayFolder = new File(gameReplayFolder, playerId);
+        File playerReplayFolder = new File(AppConfig.getReplayPath(), playerId);
         return new File(playerReplayFolder, gameId + ".xml.gz");
     }
 
     private File getRecordingFileVersion1(String playerId, String gameId, ZonedDateTime startDate) {
-        var gameReplayFolder = new File(AppConfig.getProperty("application.root"), "replay");
         //This dumb-ass formatting output is because anything that otherwise interacts with the
         // year subfield appears to trigger a JVM segfault in the guts of the java ecosystem.
         // Super-dumb.  Don't touch these two lines.
         var year = startDate.format(DateTimeFormatter.ofPattern("yyyy"));
         var month = startDate.format(DateTimeFormatter.ofPattern("MM"));
 
-        var yearFolder = new File(gameReplayFolder, year);
+        var yearFolder = new File(AppConfig.getReplayPath(), year);
         var monthFolder = new File(yearFolder, month);
         var playerReplayFolder = new File(monthFolder, playerId);
         return new File(playerReplayFolder, gameId + ".xml.gz");
     }
 
     private File getSummaryFile(DBDefs.GameHistory history) {
-        var gameReplayFolder = new File(AppConfig.getProperty("application.root"), "replay");
-        var summaryFolder = new File(gameReplayFolder, "summaries");
+        var summaryFolder = new File(AppConfig.getReplayPath(), "summaries");
         var yearFolder = new File(summaryFolder, String.format("%04d", history.start_date.getYear()));
         var monthFolder = new File(yearFolder, String.format("%02d", history.start_date.getMonthValue()));
         monthFolder.mkdirs();


### PR DESCRIPTION
Closes #44

### Summary of Changes
- Reverted recent changes made to resources.path in gemp-stccg.properties. It seems that ".." is not a suitable replacement for "/etc/module" in Docker, at least in my local environment.
- Added more detailed comments to gemp-stccg.properties
- Replaced application.root property with replay.path, since application.root was only ever used to identify the replay parent folder. Also simplified downstream calls of this value in the GameRecorder class.
- Added playtest URL strings from GameRecorder class to gemp-stccg.properties, since they were hardcoded and seemed very easy to lose track of

### Benefits
- Gemp app was crashing in Docker with the recently updated resources.path string
- More transparency on what the variables in .properties are for
- Better tracking of hardcoded playtest URL

### Risks
- Possible environment-specific conflicts. Not sure if the recent change to resources.path was necessary for @andrewd18, or just cleaning up code.
- Failure if hardcoded values for resources.path or replay.path contained typos
- Failure if hardcoded playtest URL contained typos, or if the new logic I'm using in GameRecorder didn't perfectly match the old logic. I see this as a very low risk, since this feature is effectively broken as is anyway. It relies on a LotR-specific Google doc and links in the LotR wiki.

### Testing
- Automated testing in Git PR
- Did a clean build of the Gemp app and ran it locally

### Possible improvements to this PR
- We could make both WebPath and ReplayPath more dynamic in the code by bringing back application.root and using it in the AppConfig class to determine the parent folder for both.

### Other notes
- Creating an issue to review the playtest functionality. I'm not very familiar with what's implemented in the code for playtesting. I think ideally we'd keep whatever is in the back end for it, but remove it from the UI for the MVP unless and until the CC wants to use Gemp for playtesting.