### PR TITLE
Display opponents cards upside down.

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -239,11 +239,8 @@ export default class GameAnimations {
                     "TABLE",
                     "SPACELINE",
                     "AT_LOCATION",
-                    "SUPPORT",
                     "ATTACHED",
-                    "STACKED",
-                    "REMOVED",
-                    "PLAY_PILE"
+                    "STACKED"
                 ];
 
                 if (visible_opponent_zones.includes(zone) &&

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -233,7 +233,22 @@ export default class GameAnimations {
                 if (controllerId != null)
                     participantId = controllerId;
 
-                if (zone == "SPACELINE" && participantId != that.game.bottomPlayerId) {
+                // If card is listed as public knowledge in server -> common/filterable/Zone.java
+                // and the card belongs to the opponent, inform UI to invert it.
+                let visible_opponent_zones = [
+                    "TABLE",
+                    "SPACELINE",
+                    "AT_LOCATION",
+                    "SUPPORT",
+                    "ATTACHED",
+                    "STACKED",
+                    "REMOVED",
+                    "PLAY_PILE"
+                ];
+
+                if (visible_opponent_zones.includes(zone) &&
+                    (participantId != that.game.bottomPlayerId)
+                ) {
                     var upsideDown = true;
                 } else {
                     var upsideDown = false;
@@ -277,12 +292,20 @@ export default class GameAnimations {
                     var cardDiv = getCardDivFromId(cardId);
                     var card = cardDiv.data("card");
                     var pos = cardDiv.position();
+                    let card_img = $(cardDiv).children(".card_img").first();
 
                     final_position["left"] = pos.left;
                     final_position["top"] = pos.top;
                     final_position["width"] = cardDiv.width();
                     final_position["height"] = cardDiv.height();
                     final_position["z-index"] = cardDiv.css("z-index");
+                    final_position["upside-down"] = card.upsideDown;
+
+                    if (final_position["upside-down"]) {
+                        // Don't animate a card upside down even if that's set. Class is restored in final step.
+                        $(card_img).removeClass("upside-down");
+                    }
+                    
 
                     // Now we begin the animation
                     var gameWidth = $("#main").width();
@@ -340,18 +363,23 @@ export default class GameAnimations {
                         );
                 }).queue(
                 function (next) {
-                    // Set final resting values for the card.
+                    // Set final resting values for the card, including upside-down status.
                     // TODO: This is required in order to ensure the border overlay and
                     //       token overlay display correctly after the animation.
                     //       This may not be necessary if the overlays are contained inside the
                     //       cardDiv that is being animated, as opposed to applied in layoutCardElem.
                     var cardDiv = getCardDivFromId(cardId);
+                    let card_img = $(cardDiv).children(".card_img").first();
                     layoutCardElem(cardDiv,
                         final_position["left"],
                         final_position["top"],
                         final_position["width"],
                         final_position["height"],
                         final_position["z-index"]);
+                    
+                    if (final_position["upside-down"]) {
+                        $(card_img).addClass("upside-down");
+                    }
                     next();
                 });
         }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/jCards.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/jCards.js
@@ -261,11 +261,7 @@ export default class Card {
 }
 
 
-export function createCardDiv(image, text, foil, tokens, noBorder, errata) {
-    return createCardDiv2(image, text, foil, tokens, noBorder, errata, false);
-}
-
-export function createCardDiv2(image, text, foil, tokens, noBorder, errata, upsideDown, cardId) {
+export function createCardDiv(image, text, foil, tokens, noBorder, errata, upsideDown, cardId) {
     if (cardId == null) {
         if (upsideDown)
             var imgClass = "card_img upside-down";


### PR DESCRIPTION
### Summary of Changes
In a STCCG game in real life (and in Lackey), cards are displayed facing their owner. That means the opponent's cards are displayed facing upside-down. However, when we're animating a card into place or when we're looking at a card in detail, it looks silly if that card is upside down, so we only want cards-on-table to match their IRL counterparts.

![image](https://github.com/user-attachments/assets/1181fee9-f43e-4fe2-bc71-0baaad575431)


### Benefits
- The game table looks more like a game table IRL.
- Closes #69 . Nice.

### Risks
- Players might find upside down cards annoying.
- The behavior change in createCardDiv, which is used everywhere, could possibly affect the upsideDown display or other attributes of card properties. However, since the createCardDiv2 function had the same signature as the createCardDiv function and because JS has no problem passing around nulls, I think they are ultimately identical.

### Testing
- Manual.
- Verified that opponent cards are displayed upside-down on the table.
- Verified that animation is always right-side-up.
- Verified that right-clicking on an opponent's card to see more detail renders that card right-side-up.

### Possible improvements to this PR
- People may complain that they see only the bottoms of opponents' cards when stacked. Solutions:
  1. Tell them to right-click the bottom of the card to see all the details.
  2. Make a one line code change to disable this upside-down class, which returns things to "always show everything right side up" like they were before.
  3. Make a small code change to only apply this upside-down class to missions and leave the rest of the cards right side up.