### PR TITLE
Promisify comms.getCollections and comms.getSets

### DIFF
--- a/gemp-module/gemp-stccg-client/eslint.config.mjs
+++ b/gemp-module/gemp-stccg-client/eslint.config.mjs
@@ -1,0 +1,8 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+
+
+export default [
+  {languageOptions: { globals: globals.browser }},
+  pluginJs.configs.recommended,
+];

--- a/gemp-module/gemp-stccg-client/jest.env.js
+++ b/gemp-module/gemp-stccg-client/jest.env.js
@@ -1,4 +1,8 @@
+// JQuery and JQueryUI setup
 global.window = window;
 global.$ = require('./src/main/web/js/jquery/jquery-3.7.1');
 global.jQuery = global.$;
 require('./src/main/web/js/jquery/jquery-ui-1.14.0/jquery-ui');
+
+// adds the 'fetchMock' global variable and rewires 'fetch' global to call 'fetchMock' instead of the real implementation
+require('jest-fetch-mock').enableMocks()

--- a/gemp-module/gemp-stccg-client/package-lock.json
+++ b/gemp-module/gemp-stccg-client/package-lock.json
@@ -8,7 +8,8 @@
         "@babel/preset-env": "^7.25.4",
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0"
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-fetch-mock": "^3.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3039,6 +3040,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4093,6 +4104,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -4748,6 +4770,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5012,6 +5080,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/gemp-module/gemp-stccg-client/package.json
+++ b/gemp-module/gemp-stccg-client/package.json
@@ -3,7 +3,8 @@
     "@babel/preset-env": "^7.25.4",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3"
   },
   "scripts": {
     "test": "jest"

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -276,7 +276,11 @@ export default class CardFilter {
     getCollection() {
         var that = this;
         this.getCollectionFunc((this.filter + this.calculateFullFilterPostfix()).trim(), this.start, this.count, function (xml) {
-            that.displayCollection(xml);
+            // convert incoming string to an XML DOM document, since
+            // that's what displayCollection expects
+            let xmlparser = new DOMParser();
+            var xmlDoc = xmlparser.parseFromString(xml, "text/xml");
+            that.displayCollection(xmlDoc);
         });
     }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -56,7 +56,7 @@ export default class CardFilter {
         $("#type").val(typeValue);
     }
 
-    updateSetOptions() {
+    async updateSetOptions() {
         let promise = this.comm.getSets(this.format);
         return promise.then((json) => {
             this.setSelect.empty();

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -57,8 +57,6 @@ export default class CardFilter {
     }
 
     updateSetOptions() {
-        var currentSet = this.setSelect.val();
-
         let promise = this.comm.getSets(this.format);
         return promise.then((json) => {
             this.setSelect.empty();
@@ -78,32 +76,6 @@ export default class CardFilter {
         .catch(error => {
             console.error(error);
         });
-        /*
-
-        this.comm.getSets(that.format,
-            function (json)
-            {
-                that.setSelect.empty();
-                $(json).each(function (index, o) {
-                    if (o.code == "disabled") {
-                        that.setSelect.append("<option disabled>----------</option>")
-                    } else {
-                        var $option = $("<option/>")
-                            .attr("value", o.code)
-                            .text(o.name);
-                        that.setSelect.append($option);
-                    }
-                });
-
-                that.setSelect.val(currentSet);
-            },
-            {
-                "400":function ()
-                {
-                    alert("Could not retrieve sets.");
-                }
-            });
-        */
     }
 
     buildUi(pageElem) {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -83,6 +83,40 @@ export default class CardFilter {
         });
     }
 
+    async setFilterChanged() {
+        this.filter = this.calculateNormalFilter();
+        this.start = 0
+        await this.getCollection();
+        return true;
+    };
+
+    async fullFilterChanged() {
+        this.start = 0;
+        await this.getCollection();
+        return true;
+    };
+
+    async filterOut() {
+        this.filter = this.calculateNormalFilter();
+        this.start = 0;
+        await this.getCollection();
+        return true;
+    };
+
+    async changeDynamicFilters() {
+        var cardType = $("#cardType option:selected").prop("value");
+        if (cardType.includes("EVENT")) {
+            $("#phase").show();
+        } else {
+            $("#phase").hide();
+            $("#phase").val("")
+        }
+        this.filter = this.calculateNormalFilter();
+        this.start = 0;
+        await this.getCollection();
+        return true;
+    };
+
     buildUi(pageElem) {
         var that = this;
 
@@ -93,10 +127,10 @@ export default class CardFilter {
             },
             disabled: true
         }).click(
-            function () {
+            async function () {
                 that.disableNavigation();
                 that.start -= that.count;
-                that.getCollection();
+                await that.getCollection();
             });
 
         this.nextPageBut = $("#nextPage").button({
@@ -106,10 +140,10 @@ export default class CardFilter {
             },
             disabled: true
         }).click(
-            function () {
+            async function () {
                 that.disableNavigation();
                 that.start += that.count;
-                that.getCollection();
+                await that.getCollection();
             });
 
         this.countSlider = $("#countSlider").slider({
@@ -118,10 +152,10 @@ export default class CardFilter {
             max: 40,
             step: 1,
             disabled: true,
-            slide: function (event, ui) {
+            slide: async function (event, ui) {
                 that.start = 0;
                 that.count = ui.value;
-                that.getCollection();
+                await that.getCollection();
             }
         });
 
@@ -140,55 +174,21 @@ export default class CardFilter {
             + "<option value='V'>Virtual</option>"
             + "</select>"); */
 
+        this.setSelect.on("change", async () => {await this.setFilterChanged()});
+        this.nameInput.on("change", async () => {await this.fullFilterChanged()});
+        this.sortSelect.on("change", async () => {await this.fullFilterChanged()});
+//        this.raritySelect.on("change", async () => {await this.fullFilterChanged()});
 
-        var setFilterChanged = function () {
-            that.filter = that.calculateNormalFilter();
-            that.start = 0
-            that.getCollection();
-            return true;
-        };
-
-        var fullFilterChanged = function () {
-            that.start = 0;
-            that.getCollection();
-            return true;
-        };
-
-        this.setSelect.change(setFilterChanged);
-        this.nameInput.change(fullFilterChanged);
-        this.sortSelect.change(fullFilterChanged);
-//        this.raritySelect.change(fullFilterChanged);
-
-        var filterOut = function () {
-            that.filter = that.calculateNormalFilter();
-            that.start = 0;
-            that.getCollection();
-            return true;
-        };
+        
         
         //Hide dynamic filters by default
         $("#phase").hide();
-        
-        var changeDynamicFilters = function () {
-            var cardType = $("#cardType option:selected").prop("value");
-            if (cardType.includes("EVENT")) {
-                $("#phase").show();
-            } else {
-                $("#phase").hide();
-                $("#phase").val("")
-            }
-            that.filter = that.calculateNormalFilter();
-            that.start = 0;
-            that.getCollection();
-            return true;
-            
-        };
 
-        $("#cardType").change(changeDynamicFilters);
-        $("#keyword").change(filterOut);
-        $("#type").change(filterOut);
-        $("#phase").change(filterOut);
-        $(".affiliationFilter").click(filterOut);
+        $("#cardType").on("change", async () => {await this.changeDynamicFilters()});
+        $("#keyword").on("change", async () => {await this.filterOut()});
+        $("#type").on("change", async () => {await this.filterOut()});
+        $("#phase").on("change", async () => {await this.filterOut()});
+        $(".affiliationFilter").on("click", async () => {await this.filterOut()});
         this.collectionDiv = $("#collection-display");
         //collection-display
         pageElem.append(this.collectionDiv);
@@ -275,7 +275,7 @@ export default class CardFilter {
         return filterString;
     }
 
-    getCollection() {
+    async getCollection() {
         let promise = this.comm.getCollection(
             this.collectionType,
             getUrlParam("participantId"),

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -56,8 +56,29 @@ export default class CardFilter {
     }
 
     updateSetOptions() {
-        var that = this;
-        var currentSet = that.setSelect.val();
+        var currentSet = this.setSelect.val();
+
+        let promise = this.comm.getSets(this.format);
+        promise.then((json) => {
+            this.setSelect.empty();
+            let that = this;
+            $(json).each(function (index, o) {
+                if (o.code == "disabled") {
+                    that.setSelect.append("<option disabled>----------</option>")
+                } else {
+                    var $option = $("<option/>")
+                        .attr("value", o.code)
+                        .text(o.name);
+                    that.setSelect.append($option);
+                }
+            });
+
+            this.setSelect.val(currentSet);
+        })
+        .catch(error => {
+            console.error(error);
+        });
+        /*
 
         this.comm.getSets(that.format,
             function (json)
@@ -82,6 +103,7 @@ export default class CardFilter {
                     alert("Could not retrieve sets.");
                 }
             });
+        */
     }
 
     buildUi(pageElem) {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -34,6 +34,7 @@ export default class CardFilter {
         this.comm = new GempClientCommunication("/gemp-stccg-server", that.processError);
 
         this.buildUi(pageElem);
+        // BUG: This call is async so uhhhhh creating a new CardFilter probably has a race condition.
         this.updateSetOptions();
     }
 
@@ -59,7 +60,7 @@ export default class CardFilter {
         var currentSet = this.setSelect.val();
 
         let promise = this.comm.getSets(this.format);
-        promise.then((json) => {
+        return promise.then((json) => {
             this.setSelect.empty();
             let that = this;
             $(json).each(function (index, o) {
@@ -72,8 +73,7 @@ export default class CardFilter {
                     that.setSelect.append($option);
                 }
             });
-
-            this.setSelect.val(currentSet);
+            return this.setSelect;
         })
         .catch(error => {
             console.error(error);

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -74,6 +74,8 @@ export default class CardFilter {
             return this.setSelect;
         })
         .catch(error => {
+            // NOTE: Because comm.getSets() catches all possible "return value is not JSON" errors
+            //       and because JQuery tends to error silently, this line is not testable right now.
             console.error(error);
         });
     }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/cardFilter.js
@@ -74,8 +74,11 @@ export default class CardFilter {
             return this.setSelect;
         })
         .catch(error => {
-            // NOTE: Because comm.getSets() catches all possible "return value is not JSON" errors
-            //       and because JQuery tends to error silently, this line is not testable right now.
+            // NOTE: Because comm.getSets() has the response.json() call that catches all possible
+            //       "return value is not JSON" errors, and because JQuery tends to error silently,
+            //       this line is not testable right now.
+            //       Skip it by telling babel-instanbul to ignore it.
+            /* istanbul ignore next */
             console.error(error);
         });
     }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -421,9 +421,10 @@ export default class GempClientCommunication {
         });
     }
 
-    async getCollection(collectionType, filter, start, count) {
+    async getCollection(collectionType, participantId, filter, start, count) {
         const url = this.url + "/collection/" + collectionType + "?";
         const parameters = new URLSearchParams({
+            "participantId": participantId,
             "filter": filter,
             "start": start,
             "count": count

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -437,6 +437,41 @@ export default class GempClientCommunication {
         });
     }
 
+    async getCollectionv2(collectionType, filter, start, count) {
+        const url = this.url + "/collection/" + collectionType + "?";
+        const parameters = new URLSearchParams({
+            "filter": filter,
+            "start": start,
+            "count": count
+        }).toString();
+
+        const fullurl = url + parameters;
+
+        try {
+            let response = await fetch(fullurl, {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/xml"
+                }
+            });
+
+            if (!response.ok) {
+                if (response.status == 404) {
+                    alert("You don't have collection of that type.");
+                }
+                else {
+                    throw new Error(response.statusText);
+                }
+            }
+            else {
+                return response.text();
+            }
+        }
+        catch(error) {
+            console.error({"getCollectionv2 fetch error": error.message});
+        }
+    }
+
     importCollection(decklist, callback, errorMap) {
         $.ajax({
             type:"GET",

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -421,23 +421,7 @@ export default class GempClientCommunication {
         });
     }
 
-    getCollection(collectionType, filter, start, count, callback, errorMap) {
-        $.ajax({
-            type:"GET",
-            url:this.url + "/collection/" + collectionType,
-            cache:false,
-            data:{
-                participantId:getUrlParam("participantId"),
-                filter:filter,
-                start:start,
-                count:count},
-            success:this.deliveryCheck(callback),
-            error:this.errorCheck(errorMap),
-            dataType:"xml"
-        });
-    }
-
-    async getCollectionv2(collectionType, filter, start, count) {
+    async getCollection(collectionType, filter, start, count) {
         const url = this.url + "/collection/" + collectionType + "?";
         const parameters = new URLSearchParams({
             "filter": filter,
@@ -468,7 +452,7 @@ export default class GempClientCommunication {
             }
         }
         catch(error) {
-            console.error({"getCollectionv2 fetch error": error.message});
+            console.error({"getCollection fetch error": error.message});
         }
     }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -570,7 +570,7 @@ export default class GempClientCommunication {
                 headers: {
                     "Content-Type": "application/json"
                 },
-                body: JSON.stringify({ "format": format })
+                body: `format=${format}`
             });
             
             if (!response.ok) {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -561,19 +561,34 @@ export default class GempClientCommunication {
             dataType:"html"
         });
     }
-
-    getSets(format, callback, errorMap) {
-        $.ajax({
-            type:"POST",
-            url:this.url + "/deck/sets",
-            cache:true,
-            data:{ 
-                format:format
-            },
-            success:this.deliveryCheck(callback),
-            error:this.errorCheck(errorMap),
-            dataType:"json"
-        });
+    
+    async getSets(format) {
+        const url = this.url + "/deck/sets";
+        try {
+            let response = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({ "format": format })
+            });
+            
+            if (!response.ok) {
+                if (response.status == 400) {
+                    alert("Could not retrieve sets.");
+                }
+                else {
+                    throw new Error(response.statusText);
+                }
+            }
+            else {
+                let retval = await response.json();
+                return retval;
+            }
+        }
+        catch(error) {
+            console.error({"getSets fetch error": error.message});
+        }
     }
 
     getFormats(includeEvents, callback, errorMap) {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -38,12 +38,12 @@ export default class GempLotrDeckBuildingUI {
 
         this.cardFilter = new CardFilter($("#collectionDiv"),
                 function (filter, start, count, callback) {
-                    that.comm.getCollection(that.collectionType, filter, start, count, function (xml) {
-                        callback(xml);
-                    }, {
-                        "404":function () {
-                            alert("You don't have collection of that type.");
-                        }
+                    let promise = that.comm.getCollectionv2(that.collectionType, filter, start, count);
+                    promise.then((value) => {
+                        callback(value);
+                    })
+                    .catch(error => {
+                        console.error(error);
                     });
                 },
                 function () {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -37,15 +37,7 @@ export default class GempLotrDeckBuildingUI {
 
 
         this.cardFilter = new CardFilter($("#collectionDiv"),
-                function (filter, start, count, callback) {
-                    let promise = that.comm.getCollection(that.collectionType, filter, start, count);
-                    promise.then((value) => {
-                        callback(value);
-                    })
-                    .catch(error => {
-                        console.error(error);
-                    });
-                },
+                this.collectionType,
                 function () {
                     that.clearCollection();
                 },
@@ -128,6 +120,7 @@ export default class GempLotrDeckBuildingUI {
         $("#collectionSelect").change(
                 function () {
                     that.collectionType = that.getCollectionType();
+                    that.cardFilter.setCollectionType(that.collectionType);
                     that.cardFilter.getCollection();
                 });
         this.collectionDiv.droppable({

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -38,7 +38,7 @@ export default class GempLotrDeckBuildingUI {
 
         this.cardFilter = new CardFilter($("#collectionDiv"),
                 function (filter, start, count, callback) {
-                    let promise = that.comm.getCollectionv2(that.collectionType, filter, start, count);
+                    let promise = that.comm.getCollection(that.collectionType, filter, start, count);
                     promise.then((value) => {
                         callback(value);
                     })

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -51,10 +51,11 @@ export default class GempLotrDeckBuildingUI {
                 that.formatSelect.val());
 
         $("#formatSelect").change(
-                function () {
+                async function () {
                     that.deckModified(true);
                     that.cardFilter.setFormat(that.formatSelect.val());
-                    that.cardFilter.updateSetOptions();
+                    await that.cardFilter.updateSetOptions();
+                    await that.cardFilter.setFilterChanged();
                 });
 
         var collectionSelect = $("#collectionSelect");

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/merchantUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/merchantUi.js
@@ -23,10 +23,14 @@ var GempLotrMerchantUI = Class.extend({
 
         this.comm = new GempClientCommunication("/gemp-stccg-server", that.processError);
 
-        this.cardFilter = new CardFilter(cardFilterElem, 
-                function (filter, start, count, callback) {
-                    that.comm.getMerchant(filter, that.ownedMin, start, count, callback);
-                },
+        this.cardFilter = new CardFilter(cardFilterElem,
+                // TODO: BUG: cardFilter now only calls getCollection instead of being fed a dynamic function.
+                //            Merchant functionality should be a different cardFilter type or setting within cardFilter
+                //            that changes what it calls.
+                "default",
+                //function (filter, start, count, callback) {
+                //    that.comm.getMerchant(filter, that.ownedMin, start, count, callback);
+                //},
                 function (rootElem) {
                     that.clearList(rootElem);
                 },

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/soloDraftUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/soloDraftUi.js
@@ -121,26 +121,31 @@ export default class GempLotrSoloDraftUI {
                 }
             });
 
-        this.comm.getCollection(this.leagueType, "sort:cardType,name", 0, 1000,
-            function (xml) {
-                var root = xml.documentElement;
-                if (root.tagName == "collection") {
-                    var cards = root.getElementsByTagName("card");
-                    for (var i=0; i<cards.length; i++) {
-                        var card = cards[i];
-                        var count = card.getAttribute("count");
-                        var blueprintId = card.getAttribute("blueprintId");
-                        var imageUrl = card.getAttribute("imageUrl");
-                        for (var no = 0; no < count; no++) {
-                            var card = new Card(blueprintId, "drafted", "deck", "player", imageUrl);
-                            var cardDiv = createCardDiv(card.imageUrl, null, card.isFoil(), false, false, card.hasErrata());
-                            cardDiv.data("card", card);
-                            that.draftedDiv.append(cardDiv);
-                        }
+        let promise = that.comm.getCollectionv2(this.leagueType, "sort:cardType,name", 0, 1000);
+        promise.then((xml) => {
+            let xmlparser = new DOMParser();
+            var xmlDoc = xmlparser.parseFromString(xml, "text/xml");
+            var root = xmlDoc.documentElement;
+            if (root.tagName == "collection") {
+                var cards = root.getElementsByTagName("card");
+                for (var i=0; i<cards.length; i++) {
+                    var card = cards[i];
+                    var count = card.getAttribute("count");
+                    var blueprintId = card.getAttribute("blueprintId");
+                    var imageUrl = card.getAttribute("imageUrl");
+                    for (var no = 0; no < count; no++) {
+                        var card = new Card(blueprintId, "drafted", "deck", "player", imageUrl);
+                        var cardDiv = createCardDiv(card.imageUrl, null, card.isFoil(), false, false, card.hasErrata());
+                        cardDiv.data("card", card);
+                        that.draftedDiv.append(cardDiv);
                     }
-                    that.draftedCardGroup.layoutCards();
                 }
-            });
+                that.draftedCardGroup.layoutCards();
+            }
+        })
+        .catch(error => {
+            console.error(error);
+        });
     }
 
     clickCardFunction(event) {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/soloDraftUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/soloDraftUi.js
@@ -121,7 +121,7 @@ export default class GempLotrSoloDraftUI {
                 }
             });
 
-        let promise = that.comm.getCollectionv2(this.leagueType, "sort:cardType,name", 0, 1000);
+        let promise = that.comm.getCollection(this.leagueType, "sort:cardType,name", 0, 1000);
         promise.then((xml) => {
             let xmlparser = new DOMParser();
             var xmlDoc = xmlparser.parseFromString(xml, "text/xml");

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
@@ -5,7 +5,7 @@ beforeEach(() => {
     fetchMock.resetMocks();
 });
 
-test('setCollectionType sets the collectionType', () => {
+test('setCollectionType sets the collectionType', async () => {
     document.body.innerHTML = `
             <label for="collectionSelect"></label><select id="collectionSelect">
                 <option value="default">All cards</option>
@@ -26,14 +26,14 @@ test('setCollectionType sets the collectionType', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.collectionType).toBe("default");
     cf.setCollectionType("permanent");
     expect(cf.collectionType).toBe("permanent");
 });
 
-test('setCollectionType resets the start point', () => {
+test('setCollectionType resets the start point', async () => {
     document.body.innerHTML = `
             <label for="collectionSelect"></label><select id="collectionSelect">
                 <option value="default">All cards</option>
@@ -54,7 +54,7 @@ test('setCollectionType resets the start point', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.start).toBe(0);
     cf.start = 18;
@@ -63,7 +63,7 @@ test('setCollectionType resets the start point', () => {
     expect(cf.start).toBe(0);
 });
 
-test('setFilter sets the filter', () => {
+test('setFilter sets the filter', async () => {
     // I don't know what part of the UI uses this except for merchantUI - unneeded?
     document.body.innerHTML = `
             <label for="collectionSelect"></label><select id="collectionSelect">
@@ -85,14 +85,14 @@ test('setFilter sets the filter', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.filter).toBe("");
     cf.setFilter("type:card");
     expect(cf.filter).toBe("type:card");
 });
 
-test('setFilter resets the start point', () => {
+test('setFilter resets the start point', async () => {
     // I don't know what part of the UI uses this except for merchantUI - unneeded?
     document.body.innerHTML = `
             <label for="collectionSelect"></label><select id="collectionSelect">
@@ -114,7 +114,7 @@ test('setFilter resets the start point', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.start).toBe(0);
     cf.start = 18;
@@ -123,7 +123,7 @@ test('setFilter resets the start point', () => {
     expect(cf.start).toBe(0);
 });
 
-test('setFormat sets the format', () => {
+test('setFormat sets the format', async () => {
     document.body.innerHTML = `
             <label for="formatSelect"></label><select id="formatSelect" style="float: right; width: 150px;">
 				<option value="st1emoderncomplete">ST1E Modern Complete</option>
@@ -144,14 +144,14 @@ test('setFormat sets the format', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.format).toBe("ST1E");
     cf.setFormat("tribbles");
     expect(cf.format).toBe("tribbles");
 });
 
-test('setFormat does not reset the start point', () => {
+test('setFormat does not reset the start point', async () => {
     document.body.innerHTML = `
             <label for="formatSelect"></label><select id="formatSelect" style="float: right; width: 150px;">
 				<option value="st1emoderncomplete">ST1E Modern Complete</option>
@@ -172,7 +172,7 @@ test('setFormat does not reset the start point', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     expect(cf.start).toBe(0);
     cf.start = 18;
@@ -181,7 +181,7 @@ test('setFormat does not reset the start point', () => {
     expect(cf.start).toBe(18);
 });
 
-test('setType can set the type', () => {
+test('setType can set the type', async () => {
     document.body.innerHTML = 
         '<select id="type" class="cardFilterSelect">' +
             '<option value="200">All physical card types</option>' +
@@ -200,7 +200,7 @@ test('setType can set the type', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     let selectUnderTest = $('#type');
 
@@ -209,7 +209,85 @@ test('setType can set the type', () => {
     expect(selectUnderTest.val()).toBe('101');
 });
 
-test('calculateNormalFilter none checked', () => {
+test('updateSetOptions can reset the full list', async () => {
+    document.body.innerHTML = '<select id="setSelect">' +
+    '<option value="101,103,105,106,109,112,116,123,124,125,127,128,155,159,161,163,172,178,202,204,212,244set,245">All 1E Modern Complete sets</option>' +
+    '<option disabled="">----------</option>' +
+    '<option value="101" selected="">Premiere</option>' +
+    '</select>';
+
+    let beforeclear = '<option value="101,103,105,106,109,112,116,123,124,125,127,128,155,159,161,163,172,178,202,204,212,244set,245">All 1E Modern Complete sets</option>' +
+    '<option disabled="">----------</option>' +
+    '<option value="101" selected="">Premiere</option>';
+    
+    const mockCollection = jest.fn(() => {return});
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+
+    // CardFilter initialization and every updateSetOptions requires a server call, mock them with data.
+    const getSets_retval = JSON.stringify(
+        [{"code": "1234", "name": "butts"}, {"code": "3456", "name": "in seats"}]
+    );
+    fetchMock.mockResponse(getSets_retval);
+
+    var selectUnderTest = $('#setSelect');
+    expect(selectUnderTest.html()).toBe(beforeclear);
+    expect(selectUnderTest.val()).toBe('101');
+    
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf_setsel = await cf.updateSetOptions();
+
+    expect(fetch.mock.calls.length).toEqual(2) // Fetch was called twice, once in instantiation, once in updateSetOptions
+
+    let afterClear = '<option value="1234">butts</option>' +
+    '<option value="3456">in seats</option>'
+
+    expect(selectUnderTest.html()).toBe(afterClear);
+    expect(selectUnderTest.val()).toBe('1234'); // first obj in list
+});
+
+test('updateSetOptions adds a line for disabled options', async () => {
+    document.body.innerHTML = '<select id="setSelect">' +
+    '<option value="101,103,105,106,109,112,116,123,124,125,127,128,155,159,161,163,172,178,202,204,212,244set,245">All 1E Modern Complete sets</option>' +
+    '<option disabled="">----------</option>' +
+    '<option value="101" selected="">Premiere</option>' +
+    '</select>';
+
+    let beforeclear = '<option value="101,103,105,106,109,112,116,123,124,125,127,128,155,159,161,163,172,178,202,204,212,244set,245">All 1E Modern Complete sets</option>' +
+    '<option disabled="">----------</option>' +
+    '<option value="101" selected="">Premiere</option>';
+    
+    const mockCollection = jest.fn(() => {return});
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+
+    // CardFilter initialization and every updateSetOptions requires a server call, mock them with data.
+    const getSets_retval = JSON.stringify(
+        [{"code": "1234", "name": "butts"}, {"code": "disabled", "name": "in seats"}]
+    );
+    fetchMock.mockResponse(getSets_retval);
+
+    var selectUnderTest = $('#setSelect');
+    expect(selectUnderTest.html()).toBe(beforeclear);
+    expect(selectUnderTest.val()).toBe('101');
+    
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf_setsel = await cf.updateSetOptions();
+
+    expect(fetch.mock.calls.length).toEqual(2) // Fetch was called twice, once in instantiation, once in updateSetOptions
+
+    let afterClear = '<option value="1234">butts</option>' +
+    '<option disabled="">----------</option>'
+
+    expect(selectUnderTest.html()).toBe(afterClear);
+    expect(selectUnderTest.val()).toBe('1234'); // first obj in list
+});
+
+test('calculateNormalFilter none checked', async () => {
     document.body.innerHTML = 
     '<select id="type" class="cardFilterSelect">' +
         '<option value="200">All physical card types</option>' +
@@ -247,7 +325,7 @@ test('calculateNormalFilter none checked', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
     let expectedResult = "|cardType:undefined|keyword:undefined|type:200|phase:undefined";
     let actualResult = cf.calculateNormalFilter();
@@ -255,7 +333,7 @@ test('calculateNormalFilter none checked', () => {
     expect(actualResult).toBe(expectedResult);
 });
 
-test('calculateNormalFilter Federation checked', () => {
+test('calculateNormalFilter Federation checked', async () => {
     document.body.innerHTML = 
     '<select id="type" class="cardFilterSelect">' +
         '<option value="200">All physical card types</option>' +
@@ -293,7 +371,7 @@ test('calculateNormalFilter Federation checked', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
     
     // set up a watch on the button, verify it is unchecked
     let fedInput = $("#FEDERATION");
@@ -311,7 +389,7 @@ test('calculateNormalFilter Federation checked', () => {
     expect(actualResult).toBe(expectedResult);
 });
 
-test('calculateNormalFilter Federation + Kazon checked', () => {
+test('calculateNormalFilter Federation + Kazon checked', async () => {
     document.body.innerHTML = 
     '<select id="type" class="cardFilterSelect">' +
         '<option value="200">All physical card types</option>' +
@@ -349,7 +427,7 @@ test('calculateNormalFilter Federation + Kazon checked', () => {
     );
     fetchMock.mockResponseOnce(getSets_retval);
     
-    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+    let cf = await new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
     
     // set up a watch on the button, verify it is unchecked
     let fedInput = $("#FEDERATION");

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
@@ -5,6 +5,182 @@ beforeEach(() => {
     fetchMock.resetMocks();
 });
 
+test('setCollectionType sets the collectionType', () => {
+    document.body.innerHTML = `
+            <label for="collectionSelect"></label><select id="collectionSelect">
+                <option value="default">All cards</option>
+                <option value="permanent">My cards</option>
+                <option value="trophy">Trophies</option>
+            </select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+    
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.collectionType).toBe("default");
+    cf.setCollectionType("permanent");
+    expect(cf.collectionType).toBe("permanent");
+});
+
+test('setCollectionType resets the start point', () => {
+    document.body.innerHTML = `
+            <label for="collectionSelect"></label><select id="collectionSelect">
+                <option value="default">All cards</option>
+                <option value="permanent">My cards</option>
+                <option value="trophy">Trophies</option>
+            </select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.start).toBe(0);
+    cf.start = 18;
+    expect(cf.start).toBe(18);
+    cf.setCollectionType("permanent");
+    expect(cf.start).toBe(0);
+});
+
+test('setFilter sets the filter', () => {
+    // I don't know what part of the UI uses this except for merchantUI - unneeded?
+    document.body.innerHTML = `
+            <label for="collectionSelect"></label><select id="collectionSelect">
+                <option value="default">All cards</option>
+                <option value="permanent">My cards</option>
+                <option value="trophy">Trophies</option>
+            </select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+    
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.filter).toBe("");
+    cf.setFilter("type:card");
+    expect(cf.filter).toBe("type:card");
+});
+
+test('setFilter resets the start point', () => {
+    // I don't know what part of the UI uses this except for merchantUI - unneeded?
+    document.body.innerHTML = `
+            <label for="collectionSelect"></label><select id="collectionSelect">
+                <option value="default">All cards</option>
+                <option value="permanent">My cards</option>
+                <option value="trophy">Trophies</option>
+            </select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.start).toBe(0);
+    cf.start = 18;
+    expect(cf.start).toBe(18);
+    cf.setFilter("type:card");
+    expect(cf.start).toBe(0);
+});
+
+test('setFormat sets the format', () => {
+    document.body.innerHTML = `
+            <label for="formatSelect"></label><select id="formatSelect" style="float: right; width: 150px;">
+				<option value="st1emoderncomplete">ST1E Modern Complete</option>
+                <option value="st2e">2E All</option>
+                <option value="tribbles">Tribbles</option>
+			</select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+    
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.format).toBe("ST1E");
+    cf.setFormat("tribbles");
+    expect(cf.format).toBe("tribbles");
+});
+
+test('setFormat does not reset the start point', () => {
+    document.body.innerHTML = `
+            <label for="formatSelect"></label><select id="formatSelect" style="float: right; width: 150px;">
+				<option value="st1emoderncomplete">ST1E Modern Complete</option>
+                <option value="st2e">2E All</option>
+                <option value="tribbles">Tribbles</option>
+			</select>
+            `;
+
+    const mockCollection = "default";
+    const mockClearCollection = jest.fn(() => {return});
+    const mockAddCard = jest.fn(() => {return});
+    const mockFinishCollection = jest.fn(() => {return});
+    const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
+    
+    let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
+
+    expect(cf.start).toBe(0);
+    cf.start = 18;
+    expect(cf.start).toBe(18);
+    cf.setFormat("tribbles");
+    expect(cf.start).toBe(18);
+});
+
 test('setType can set the type', () => {
     document.body.innerHTML = 
         '<select id="type" class="cardFilterSelect">' +

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/cardFilter.test.js
@@ -1,5 +1,10 @@
 import CardFilter from "../gemp-022/cardFilter.js";
 
+beforeEach(() => {
+    // clear any stored fetch mock statistics
+    fetchMock.resetMocks();
+});
+
 test('setType can set the type', () => {
     document.body.innerHTML = 
         '<select id="type" class="cardFilterSelect">' +
@@ -12,6 +17,12 @@ test('setType can set the type', () => {
     const mockAddCard = jest.fn(() => {return});
     const mockFinishCollection = jest.fn(() => {return});
     const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
     
     let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
@@ -53,6 +64,12 @@ test('calculateNormalFilter none checked', () => {
     const mockAddCard = jest.fn(() => {return});
     const mockFinishCollection = jest.fn(() => {return});
     const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
     
     let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
 
@@ -93,6 +110,12 @@ test('calculateNormalFilter Federation checked', () => {
     const mockAddCard = jest.fn(() => {return});
     const mockFinishCollection = jest.fn(() => {return});
     const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
     
     let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
     
@@ -143,6 +166,12 @@ test('calculateNormalFilter Federation + Kazon checked', () => {
     const mockAddCard = jest.fn(() => {return});
     const mockFinishCollection = jest.fn(() => {return});
     const mockFormat = "ST1E";
+
+    // CardFilter initialization requires a server call, mock it with data.
+    const getSets_retval = JSON.stringify(
+        {"updateSetOptions": []}
+    );
+    fetchMock.mockResponseOnce(getSets_retval);
     
     let cf = new CardFilter(document.body, mockCollection, mockClearCollection, mockAddCard, mockFinishCollection, mockFormat);
     

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
@@ -5,7 +5,7 @@ beforeEach(() => {
     fetchMock.resetMocks();
 });
 
-test('getCollectionv2 sends a default URL to the server', async () => {
+test('getCollection sends a default URL to the server', async () => {
     let url = "/gemp-stccg-server";
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
@@ -17,14 +17,14 @@ test('getCollectionv2 sends a default URL to the server', async () => {
 
     let expected_call_string = url + "/collection/" + collectionType + "?filter=" + filter + "&start=" + start + "&count=" + count;
 
-    let actual = await comms.getCollectionv2(collectionType, filter, start, count);
+    let actual = await comms.getCollection(collectionType, filter, start, count);
     
     expect(fetch.mock.calls.length).toEqual(1) // Fetch was called once
     let lastcall_firstarg = fetch.mock.lastCall[0];
     expect(lastcall_firstarg).toEqual(expected_call_string); // Fetch called the right URL
 });
 
-test('getCollectionv2 waits for and gives us a string of what the server gave us', async () => {
+test('getCollection waits for and gives us a string of what the server gave us', async () => {
     const server_retval = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><collection count="119"><card blueprintId="101_196" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/alexanderrozhenko95.jpg"/><card blueprintId="101_197" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/alynnanechayev95.jpg"/><card blueprintId="101_198" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/comingofage/8.jpg"/><card blueprintId="101_289" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/amarie95.jpg"/><card blueprintId="101_146" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/avertdisaster95.jpg"/><card blueprintId="101_252" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/betor95.jpg"/><card blueprintId="101_253" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/bijik95.jpg"/><card blueprintId="101_290" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/tngsup/33V.jpg"/><card blueprintId="101_254" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/batrell95.jpg"/><card blueprintId="101_199" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/sfls/18.jpg"/><card blueprintId="101_200" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/beverlycrusher95.jpg"/><card blueprintId="101_201" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/twtstarters/calloway.jpg"/><card blueprintId="101_202" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/christopherhobson95.jpg"/><card blueprintId="101_147" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/errata/Cloaked-Mission.jpg"/><card blueprintId="101_148" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/errata/Covert-Installation.jpg"/><card blueprintId="101_149" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/covertrescue95.jpg"/><card blueprintId="101_150" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/culturalobservation95.jpg"/><card blueprintId="101_357" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/dderidex95.jpg"/></collection>';
     fetchMock.mockResponse(server_retval);
 
@@ -37,12 +37,12 @@ test('getCollectionv2 waits for and gives us a string of what the server gave us
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, filter, start, count);
     
     expect(actual_string).toBe(server_retval);
 });
 
-test('getCollectionv2 handles 404s', async () => {
+test('getCollection handles 404s', async () => {
     const server_retval = new Response("Not Found", {status: 404});
     fetchMock.mockResolvedValue(server_retval);
     window.alert = jest.fn(() => ({}));
@@ -59,19 +59,19 @@ test('getCollectionv2 handles 404s', async () => {
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, filter, start, count);
     
     expect(alertmock.mock.calls.length).toEqual(1) // Alert was called once
     let lastcall_firstarg = alertmock.mock.lastCall[0];
     expect(lastcall_firstarg).toEqual(alerttext); // Alert had the expected text.
 });
 
-test('getCollectionv2 handles non-404s with a console.error', async () => {
+test('getCollection handles non-404s with a console.error', async () => {
     const server_retval = new Response("Forbidden", {status: 403});
     fetchMock.mockResolvedValue(server_retval);
     console.error = jest.fn(() => ({}));
     let errmock = jest.spyOn(console, 'error');
-    let errmockobj = {"getCollectionv2 fetch error": "Forbidden"};
+    let errmockobj = {"getCollection fetch error": "Forbidden"};
     
 
     let url = "/gemp-stccg-server";
@@ -83,18 +83,18 @@ test('getCollectionv2 handles non-404s with a console.error', async () => {
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, filter, start, count);
     
     expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
     let lastcall_firstarg = errmock.mock.lastCall[0];
     expect(lastcall_firstarg).toEqual(errmockobj); // Console.error had the expected output.
 });
 
-test('getCollectionv2 handles fetch errors with a console.error', async () => {
+test('getCollection handles fetch errors with a console.error', async () => {
     fetchMock.mockReject(new Error('fake error message'));
     console.error = jest.fn(() => ({}));
     let errmock = jest.spyOn(console, 'error');
-    let errmockobj = {"getCollectionv2 fetch error": "fake error message"};
+    let errmockobj = {"getCollection fetch error": "fake error message"};
     
 
     let url = "/gemp-stccg-server";
@@ -106,7 +106,7 @@ test('getCollectionv2 handles fetch errors with a console.error', async () => {
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, filter, start, count);
     
     expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
     let lastcall_firstarg = errmock.mock.lastCall[0];

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
@@ -131,7 +131,7 @@ test('getSets sends the correct data to the server', async () => {
     const format = "st1emoderncomplete";
 
     let expected_call_string = url + "/deck/sets";
-    let expected_call_body = JSON.stringify({"format": format});
+    let expected_call_body = `format=${format}`;
 
     let actual = await comms.getSets(format);
     

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
@@ -10,14 +10,15 @@ test('getCollection sends a default URL to the server', async () => {
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
 
+    const participantId = "nsoong";
     const collectionType = "default";
     const filter = "";
     const start = 0;
     const count = 18;
 
-    let expected_call_string = url + "/collection/" + collectionType + "?filter=" + filter + "&start=" + start + "&count=" + count;
+    let expected_call_string = url + "/collection/" + collectionType + "?participantId=" + participantId + "&filter=" + filter + "&start=" + start + "&count=" + count;
 
-    let actual = await comms.getCollection(collectionType, filter, start, count);
+    let actual = await comms.getCollection(collectionType, participantId, filter, start, count);
     
     expect(fetch.mock.calls.length).toEqual(1) // Fetch was called once
     let lastcall_firstarg = fetch.mock.lastCall[0];
@@ -32,12 +33,13 @@ test('getCollection waits for and gives us a string of what the server gave us',
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
 
+    const participantId = "nsoong";
     const collectionType = "default";
     const filter = "";
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollection(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, participantId, filter, start, count);
     
     expect(actual_string).toBe(server_retval);
 });
@@ -54,12 +56,13 @@ test('getCollection handles 404s', async () => {
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
 
+    const participantId = "nsoong";
     const collectionType = "default";
     const filter = "";
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollection(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, participantId, filter, start, count);
     
     expect(alertmock.mock.calls.length).toEqual(1) // Alert was called once
     let lastcall_firstarg = alertmock.mock.lastCall[0];
@@ -78,12 +81,13 @@ test('getCollection handles non-404s with a console.error', async () => {
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
 
+    const participantId = "nsoong";
     const collectionType = "default";
     const filter = "";
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollection(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, participantId, filter, start, count);
     
     expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
     let lastcall_firstarg = errmock.mock.lastCall[0];
@@ -101,12 +105,13 @@ test('getCollection handles fetch errors with a console.error', async () => {
     let failure = null;
     let comms = new GempClientCommunication(url, failure);
 
+    const participantId = "nsoong";
     const collectionType = "default";
     const filter = "";
     const start = 0;
     const count = 18;
 
-    let actual_string = await comms.getCollection(collectionType, filter, start, count);
+    let actual_string = await comms.getCollection(collectionType, participantId, filter, start, count);
     
     expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
     let lastcall_firstarg = errmock.mock.lastCall[0];

--- a/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/tests/communications.test.js
@@ -1,0 +1,114 @@
+import GempClientCommunication from "../gemp-022/communication.js";
+
+beforeEach(() => {
+    // clear any stored fetch mock statistics
+    fetchMock.resetMocks();
+});
+
+test('getCollectionv2 sends a default URL to the server', async () => {
+    let url = "/gemp-stccg-server";
+    let failure = null;
+    let comms = new GempClientCommunication(url, failure);
+
+    const collectionType = "default";
+    const filter = "";
+    const start = 0;
+    const count = 18;
+
+    let expected_call_string = url + "/collection/" + collectionType + "?filter=" + filter + "&start=" + start + "&count=" + count;
+
+    let actual = await comms.getCollectionv2(collectionType, filter, start, count);
+    
+    expect(fetch.mock.calls.length).toEqual(1) // Fetch was called once
+    let lastcall_firstarg = fetch.mock.lastCall[0];
+    expect(lastcall_firstarg).toEqual(expected_call_string); // Fetch called the right URL
+});
+
+test('getCollectionv2 waits for and gives us a string of what the server gave us', async () => {
+    const server_retval = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><collection count="119"><card blueprintId="101_196" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/alexanderrozhenko95.jpg"/><card blueprintId="101_197" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/alynnanechayev95.jpg"/><card blueprintId="101_198" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/comingofage/8.jpg"/><card blueprintId="101_289" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/amarie95.jpg"/><card blueprintId="101_146" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/avertdisaster95.jpg"/><card blueprintId="101_252" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/betor95.jpg"/><card blueprintId="101_253" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/bijik95.jpg"/><card blueprintId="101_290" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/tngsup/33V.jpg"/><card blueprintId="101_254" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/batrell95.jpg"/><card blueprintId="101_199" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/sfls/18.jpg"/><card blueprintId="101_200" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/beverlycrusher95.jpg"/><card blueprintId="101_201" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/twtstarters/calloway.jpg"/><card blueprintId="101_202" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/christopherhobson95.jpg"/><card blueprintId="101_147" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/errata/Cloaked-Mission.jpg"/><card blueprintId="101_148" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/errata/Covert-Installation.jpg"/><card blueprintId="101_149" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/covertrescue95.jpg"/><card blueprintId="101_150" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/culturalobservation95.jpg"/><card blueprintId="101_357" count="4" imageUrl="https://www.trekcc.org/1e/cardimages/premiere/dderidex95.jpg"/></collection>';
+    fetchMock.mockResponse(server_retval);
+
+    let url = "/gemp-stccg-server";
+    let failure = null;
+    let comms = new GempClientCommunication(url, failure);
+
+    const collectionType = "default";
+    const filter = "";
+    const start = 0;
+    const count = 18;
+
+    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    
+    expect(actual_string).toBe(server_retval);
+});
+
+test('getCollectionv2 handles 404s', async () => {
+    const server_retval = new Response("Not Found", {status: 404});
+    fetchMock.mockResolvedValue(server_retval);
+    window.alert = jest.fn(() => ({}));
+    let alertmock = jest.spyOn(window, 'alert');
+    let alerttext = "You don't have collection of that type.";
+    
+
+    let url = "/gemp-stccg-server";
+    let failure = null;
+    let comms = new GempClientCommunication(url, failure);
+
+    const collectionType = "default";
+    const filter = "";
+    const start = 0;
+    const count = 18;
+
+    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    
+    expect(alertmock.mock.calls.length).toEqual(1) // Alert was called once
+    let lastcall_firstarg = alertmock.mock.lastCall[0];
+    expect(lastcall_firstarg).toEqual(alerttext); // Alert had the expected text.
+});
+
+test('getCollectionv2 handles non-404s with a console.error', async () => {
+    const server_retval = new Response("Forbidden", {status: 403});
+    fetchMock.mockResolvedValue(server_retval);
+    console.error = jest.fn(() => ({}));
+    let errmock = jest.spyOn(console, 'error');
+    let errmockobj = {"getCollectionv2 fetch error": "Forbidden"};
+    
+
+    let url = "/gemp-stccg-server";
+    let failure = null;
+    let comms = new GempClientCommunication(url, failure);
+
+    const collectionType = "default";
+    const filter = "";
+    const start = 0;
+    const count = 18;
+
+    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    
+    expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
+    let lastcall_firstarg = errmock.mock.lastCall[0];
+    expect(lastcall_firstarg).toEqual(errmockobj); // Console.error had the expected output.
+});
+
+test('getCollectionv2 handles fetch errors with a console.error', async () => {
+    fetchMock.mockReject(new Error('fake error message'));
+    console.error = jest.fn(() => ({}));
+    let errmock = jest.spyOn(console, 'error');
+    let errmockobj = {"getCollectionv2 fetch error": "fake error message"};
+    
+
+    let url = "/gemp-stccg-server";
+    let failure = null;
+    let comms = new GempClientCommunication(url, failure);
+
+    const collectionType = "default";
+    const filter = "";
+    const start = 0;
+    const count = 18;
+
+    let actual_string = await comms.getCollectionv2(collectionType, filter, start, count);
+    
+    expect(errmock.mock.calls.length).toEqual(1) // Console.error was called once
+    let lastcall_firstarg = errmock.mock.lastCall[0];
+    expect(lastcall_firstarg).toEqual(errmockobj); // Console.error had the expected output.
+});


### PR DESCRIPTION
### Summary of Changes
This is a first of a long series of overhauls to begin fully unit testing our comms stack. This PR:

1. Enhances the NodeJS test environment to support testing using JQuery UI functions.
2. Converts comms.getCollections and comms.getSets from their callback functions to ES6 fetch() functions that use Promises.
3. Creates unit tests for comms.getCollections and comms.getSets and ensures they are 100% unit tested.
4. Adds an eslint config file to perform static analysis and report issues lurking in the JS, where possible. Should be editor-agnostic, if the editor can use eslint.

### Benefits
- Sets a new precedent for testing Comms functions and tests - we can write tests that pretend to be the server and verify the JS side performs the correct actions.
- Clarifies order of operations by removing callbacks - promise functions return values rather than calling another function which calls another function, etc.
- Moves logic that used to be scattered around the code base into clearly defined areas of responsibility.
- Closes #93 

### Risks
Promises are inherently asynchronous. The callback-style functions we use elsewhere are a synchronous, blocking design, meaning that if the server is delayed in the getCollections call, the UI would not render until the response arrived. I am mimicking that here with the promise.then() design in cardFilter.js, and it was working fine when I tested it. However:
* The DeckBuilder constructor calls the CardFilter constructor. CardFilter previously called a synchronous comms call which is now asynchronous. This could cause CardFilter to act funny until the server resolves. It was working fine in manual testing.

### Testing
- Fully automated. As of the time of this PR, comms.getCollections and comms.getSets are 100% unit tested. Comms as a whole is 19% unit tested and cardFilter is 74% unit tested.
- Messed around in the Deck Builder to verify it continued to work as intended.

### Possible improvements to this PR
- To completely eliminate the risk above, the entire deck builder UI (and hall and game UI and anything else that uses comms :scream:   ) need to be redesigned. This is skipped here for MVP-and-time reasons. The changes are:
  - Have constructors return empty-but-functional objects, like empty combo boxes.
  - Any place where we would do a comms call in a constructor, move that out into a post-object-instantiation setup() call or something similar, since that will be an async call.

### Other notes
- I was really hoping this would be a bigger PR where I could convert a lot of comms in one go, but every time I made a change to the comms stack it would ripple up with async calls and break other things. I will need to continue to do this piece by piece.