### PR TITLE
Removed "Revert" from client

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1547,7 +1547,6 @@ export default class GameTableUI {
         var actionTexts = this.getDecisionParameters(decision, "actionText");
         var actionTypes = this.getDecisionParameters(decision, "actionType");
         var noPass = this.getDecisionParameters(decision, "noPass");
-        var isRevertEligible = this.getDecisionParameters(decision, "revertEligible");
 
         var that = this;
 
@@ -1570,12 +1569,6 @@ export default class GameTableUI {
                     finishChoice();
                 });
             }
-            if (isRevertEligible == "true") {
-                that.alertButtons.append("<button id='Revert' style='float: right'>Revert</button>");
-                $("#Revert").button().click(function () {
-                    finishChoice(true);
-                });
-            }
             if (selectedCardIds.length > 0) {
                 that.alertButtons.append("<button id='ClearSelection'>Reset choice</button>");
                 that.alertButtons.append("<button id='Done' style='float: right'>Done</button>");
@@ -1588,7 +1581,7 @@ export default class GameTableUI {
             }
         };
 
-        var finishChoice = function (isRevert) {
+        var finishChoice = function () {
             that.alertText.html("");
             // ****CCG League****: Border around alert box
             that.alertBox.removeClass("alert-box-highlight");
@@ -1601,9 +1594,6 @@ export default class GameTableUI {
                         $(this).remove();
                 });
             that.hand.layoutCards();
-            if (isRevert) {
-                that.decisionFunction(id, "revert");
-            }
             else {
                 that.decisionFunction(id, "" + selectedCardIds);
             }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/decisions/CardActionSelectionDecision.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/decisions/CardActionSelectionDecision.java
@@ -10,20 +10,17 @@ import java.util.List;
 public abstract class CardActionSelectionDecision extends ActionDecision {
 
     public CardActionSelectionDecision(Player player, String text, List<Action> actions) {
-        this(player, text, actions, false, true);
+        this(player, text, actions, false);
     }
 
 
-    public CardActionSelectionDecision(Player player, String text, List<Action> actions, boolean noPass,
-                                       boolean revertEligible) {
+    public CardActionSelectionDecision(Player player, String text, List<Action> actions, boolean noPass) {
         super(player, text, actions, AwaitingDecisionType.CARD_ACTION_CHOICE);
         setParam("cardId", getCardIds());
         setParam("blueprintId", getBlueprintIds()); // done in super
         setParam("imageUrl", getImageUrls()); // done in super
         setParam("actionType", getActionTypes());
         setParam("noPass", String.valueOf(noPass));
-        // TODO SNAPSHOT - no methods for "revertEligible" in client
-        setParam("revertEligible", String.valueOf(revertEligible));
     }
 
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/ST1EMissionSeedPhaseProcess.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/ST1EMissionSeedPhaseProcess.java
@@ -43,7 +43,7 @@ public class ST1EMissionSeedPhaseProcess extends ST1EGameProcess {
             String message = "Play " + currentPhase + " action";
             Player player = _game.getCurrentPlayer();
             _game.getUserFeedback().sendAwaitingDecision(
-                    new CardActionSelectionDecision(player, message, playableActions, true, true) {
+                    new CardActionSelectionDecision(player, message, playableActions, true) {
                         @Override
                         public void decisionMade(String result) throws DecisionResultInvalidException {
                             if ("revert".equalsIgnoreCase(result))


### PR DESCRIPTION
Closes #84

The "Revert" option in the client was added to be able to load a game state, effectively undoing previous actions. It sort of works, but sort of not, and doesn't look great where it's placed.

Ultimately (not even that far in the long-term), I'd rather see this implemented as an option during any point in the game. If the player should have the ability to revert previous decisions, there's no reason to couple it to other decisions. It should be constantly available, like the ability to view your discard pile or right-click on a card for card info.

So for now, let's cut it until it works as intended.