### PR TITLE
Fixed the dangling "else" in the finishChoice method

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1594,9 +1594,7 @@ export default class GameTableUI {
                         $(this).remove();
                 });
             that.hand.layoutCards();
-            else {
-                that.decisionFunction(id, "" + selectedCardIds);
-            }
+            that.decisionFunction(id, "" + selectedCardIds);
         };
 
         var resetChoice = function () {


### PR DESCRIPTION
What it says on the tin. PR #94 removed an "if" statement but left the "else". The "else" condition has been removed so this is no longer causing a bug.

Still passing all automated tests. Ran the code on my end with a deck that included multiple doorways to make sure the card selection function would be triggered immediately. No problems.