### PR TITLE
Add background colors and on-hover titles to quadrants

### DIFF
--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set123.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set123.hjson
@@ -1,12 +1,10 @@
-// Set 123: Voyager
-
 {
     setId: "123"
     setName: Voyager
     gameType: First Edition
     cards: [
         {
-            blueprintId: 123_79
+            blueprintId: 123_079
             title: Aftermath
             type: mission
             mission-type: planet

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set123.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set123.hjson
@@ -6,6 +6,20 @@
     gameType: First Edition
     cards: [
         {
+            blueprintId: 123_79
+            title: Aftermath
+            type: mission
+            mission-type: planet
+            location: Lifeless world
+            lore: Determine cause of a disaster that obliterated all life on this once-thriving planet.
+            mission-requirements: ENGINEER + Physics x2 + (Honor OR Treachery)
+            affiliation-icons: federation,romulan,non-aligned
+            point-box: 35
+            span: 4
+            quadrant: delta
+            image-url: https://www.trekcc.org/1e/cardimages/voy/aftermath.jpg
+        }
+        {
             blueprintId: 123_193
             title: U.S.S. Intrepid
             type: ship

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set181.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set181.hjson
@@ -1,12 +1,10 @@
-// Set 181: Crossover
-
 {
     setId: "181"
     setName: Crossover
     gameType: First Edition
     cards: [
         {
-            blueprintId: 181_37
+            blueprintId: 181_037
             title: Investigate Intrusion
             type: mission
             mission-type: space

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set181.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set181.hjson
@@ -1,0 +1,24 @@
+// Set 181: Crossover
+
+{
+    setId: "181"
+    setName: Crossover
+    gameType: First Edition
+    cards: [
+        {
+            blueprintId: 181_37
+            title: Investigate Intrusion
+            type: mission
+            mission-type: space
+            region: Bajor
+            location: Denorios Belt
+            lore: Evaluate threat posed by ship after sudden appearance.
+            mission-requirements: Leadership + SECURITY + OFFICER + STRENGTH>30
+            affiliation-icons: klingon,cardassian
+            point-box: 30
+            span: 3
+            quadrant: mirror
+            image-url: https://www.trekcc.org/1e/cardimages/crossover/37.jpg
+        }
+    ]
+}

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -418,7 +418,7 @@ ul {
 }
 
 .delta-quadrant {
-    background: rgba(118, 119, 21, 0.2);
+    background: rgba(255, 255, 0, 0.2);
     z-index: 10;
 }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -407,6 +407,26 @@ ul {
     border-right-color: white;
 }
 
+.alpha-quadrant {
+    background: linear-gradient(to right, rgba(21, 24, 119, 0.2), rgba(21, 24, 119, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+}
+
+.gamma-quadrant {
+    background: linear-gradient(to right, rgba(21, 119, 21, 0.2), rgba(21, 119, 21, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+}
+
+.delta-quadrant {
+    background: linear-gradient(to right, rgba(118, 119, 21, 0.2), rgba(118, 119, 21, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+}
+
+.mirror-quadrant {
+    background: linear-gradient(to right, rgba(142, 29, 29, 0.2), rgba(142, 29, 29, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+}
+
+.st1e-card-group {
+    background: none;
+}
+
 .upside-down {
     transform: rotateX(180deg) rotateY(180deg);
 }

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -408,23 +408,27 @@ ul {
 }
 
 .alpha-quadrant {
-    background: linear-gradient(to right, rgba(21, 24, 119, 0.2), rgba(21, 24, 119, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+    background: rgba(21, 24, 119, 0.2);
+    z-index: 10;
 }
 
 .gamma-quadrant {
-    background: linear-gradient(to right, rgba(21, 119, 21, 0.2), rgba(21, 119, 21, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+    background: rgba(21, 119, 21, 0.2);
+    z-index: 10;
 }
 
 .delta-quadrant {
-    background: linear-gradient(to right, rgba(118, 119, 21, 0.2), rgba(118, 119, 21, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+    background: rgba(118, 119, 21, 0.2);
+    z-index: 10;
 }
 
 .mirror-quadrant {
-    background: linear-gradient(to right, rgba(142, 29, 29, 0.2), rgba(142, 29, 29, 0.2)), url('../dark-hive/images/ui-bg_loop_25_000000_21x21.png');
+    background: rgba(142, 29, 29, 0.2);
+    z-index: 10;
 }
 
 .st1e-card-group {
-    background: none;
+    z-index: 9;
 }
 
 .upside-down {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -2365,7 +2365,6 @@ export class ST1EGameTableUI extends GameTableUI {
             this.hand.layoutCards();
         }
 
-            // LOCATION CODE FROM SWCCG GEMP
         var locationsCount = this.locationDivs.length;
 
         var zoomedInLocationDivWidth = (width / Math.min(3.25, locationsCount)) - (LOCATION_BORDER_PADDING / 2);
@@ -2395,6 +2394,19 @@ export class ST1EGameTableUI extends GameTableUI {
                 this.locationDivs[locationIndex].removeClass("last-in-quadrant");
             }
 
+            if (currQuadrant == "ALPHA" ) {
+                this.locationDivs[locationIndex].addClass("alpha-quadrant");
+            }
+            if (currQuadrant == "GAMMA" ) {
+                this.locationDivs[locationIndex].addClass("gamma-quadrant");
+            }
+            if (currQuadrant == "DELTA" ) {
+                this.locationDivs[locationIndex].addClass("delta-quadrant");
+            }
+            if (currQuadrant == "MIRROR" ) {
+                this.locationDivs[locationIndex].addClass("mirror-quadrant");
+            }
+
             this.missionCardGroups[locationIndex].setBounds(x, y + locationDivHeight/3, locationDivWidth, locationDivHeight/3);
             this.missionCardGroups[locationIndex].layoutCards();
             this.opponentAtLocationCardGroups[locationIndex].setBounds(x, y, locationDivWidth, locationDivHeight / 3);
@@ -2404,7 +2416,6 @@ export class ST1EGameTableUI extends GameTableUI {
 
             x = (x + locationDivWidth + (LOCATION_BORDER_PADDING / 2));
         }
-                // END OF SWCCG GEMP LOCATION CODE
 
         for (var playerId in this.discardPileGroups)
             if (this.discardPileGroups.hasOwnProperty(playerId))

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -2396,15 +2396,19 @@ export class ST1EGameTableUI extends GameTableUI {
 
             if (currQuadrant == "ALPHA" ) {
                 this.locationDivs[locationIndex].addClass("alpha-quadrant");
+                this.locationDivs[locationIndex].attr("title", "Alpha Quadrant");
             }
             if (currQuadrant == "GAMMA" ) {
                 this.locationDivs[locationIndex].addClass("gamma-quadrant");
+                this.locationDivs[locationIndex].attr("title", "Gamma Quadrant");
             }
             if (currQuadrant == "DELTA" ) {
                 this.locationDivs[locationIndex].addClass("delta-quadrant");
+                this.locationDivs[locationIndex].attr("title", "Delta Quadrant");
             }
             if (currQuadrant == "MIRROR" ) {
                 this.locationDivs[locationIndex].addClass("mirror-quadrant");
+                this.locationDivs[locationIndex].attr("title", "Mirror Quadrant");
             }
 
             this.missionCardGroups[locationIndex].setBounds(x, y + locationDivHeight/3, locationDivWidth, locationDivHeight/3);


### PR DESCRIPTION
### Summary of Changes
Adds unique background colors for each quadrant. Uses transparency so you can still see the position squares beneath.

Delta: Yellow
Mirror: Red
Alpha: Blue
Gamma: Green

![image](https://github.com/user-attachments/assets/efe65423-dc1e-41e2-94f7-8d15e6e65c8e)

Adds tooltips when you hover over the background indicating what quadrant it is.

![image](https://github.com/user-attachments/assets/7b7c082b-e655-45b6-b316-f27d8347ae0f)


### Benefits
- You can begin to understand why the card puts some cards in one place vs another.

### Risks
- Makes it harder for some colorblind people to see what's going on; an accepted risk until we get the overhaul in and can address accessibility issues.

### Testing
- Manual

### Possible improvements to this PR
- None for MVP scope that I can think of.