### PR TITLE
Validate deck blueprints

### DIFF
--- a/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/CardDeck.java
+++ b/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/CardDeck.java
@@ -57,6 +57,13 @@ public class CardDeck {
         _subDecks.get(subDeck).add(blueprintId);
     }
     public List<String> getDrawDeckCards() { return _subDecks.get(SubDeck.DRAW_DECK); }
+    public List<String> getAllCards() {
+        List<String> result = new LinkedList<>();
+        for (List<String> subDeckCards : _subDecks.values()) {
+            result.addAll(subDeckCards);
+        }
+        return result;
+    }
 
     public Map<SubDeck, List<String>> getSubDecks() { return _subDecks; }
     public List<String> getSubDeck(SubDeck subDeck) { return _subDecks.get(subDeck); }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/CardBlueprintLibrary.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/CardBlueprintLibrary.java
@@ -321,7 +321,7 @@ public class CardBlueprintLibrary {
         }
 
         // Throw exception if card not found in blueprints
-        throw new CardNotFoundException(blueprintId1);
+        throw new CardNotFoundException("Unable to find card blueprint for id '" + blueprintId1 + "'");
     }
 
     public String stripBlueprintModifiers(String blueprintId) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
@@ -301,7 +301,7 @@ public class DefaultGameFormat implements GameFormat {
         }
 
         String newLine;
-        for (String card : deck.getDrawDeckCards()){
+        for (String card : deck.getAllCards()){
             newLine = validateCard(card);
             if(newLine == null || newLine.isEmpty())
                 continue;
@@ -317,7 +317,7 @@ public class DefaultGameFormat implements GameFormat {
         Map<String, Integer> cardCountByName = new HashMap<>();
         Map<String, Integer> cardCountByBaseBlueprintId = new HashMap<>();
 
-        for (String blueprintId : deck.getDrawDeckCards())
+        for (String blueprintId : deck.getAllCards())
             try {
                 processCardCounts(blueprintId, cardCountByName, cardCountByBaseBlueprintId);
             } catch(CardNotFoundException exp) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
@@ -321,7 +321,7 @@ public class DefaultGameFormat implements GameFormat {
             try {
                 processCardCounts(blueprintId, cardCountByName, cardCountByBaseBlueprintId);
             } catch(CardNotFoundException exp) {
-                result.add("Draw deck contains card of invalid blueprintId '" + blueprintId + "'");
+                result.add("Deck contains card of invalid blueprintId '" + blueprintId + "'");
             }
 
         for (Map.Entry<String, Integer> count : cardCountByName.entrySet()) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/ST1EGameState.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/ST1EGameState.java
@@ -62,7 +62,7 @@ public class ST1EGameState extends GameState implements Snapshotable<ST1EGameSta
                         _allCards.put(_nextCardId, card);
                         _nextCardId++;
                     } catch (CardNotFoundException e) {
-                        throw new RuntimeException("Card blueprint not found");
+                        _game.sendErrorMessage(e);
                     }
                 }
                 if (entry.getKey() == SubDeck.DRAW_DECK) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/TribblesGameState.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/TribblesGameState.java
@@ -61,7 +61,7 @@ public final class TribblesGameState extends GameState {
                         subDeck.add(card);
                         _nextCardId++;
                     } catch (CardNotFoundException e) {
-                        throw new RuntimeException("Card blueprint not found");
+                        _game.sendErrorMessage(e);
                     }
                 }
                 if (Objects.equals(entry.getKey().name(), "DRAW_DECK")) {

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/hall/HallServer.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/hall/HallServer.java
@@ -409,8 +409,8 @@ public class HallServer extends AbstractServer {
                 firstValidation = firstValidation.substring(0, firstValidation.indexOf("\n"));
             long issueCount = validations.size() + newLineCount;
             StringBuilder validationMessage = new StringBuilder();
-            validationMessage.append("Your selected deck is not valid for this format: ");
-            validationMessage.append("Deck is incompatible with '").append(format.getName()).append("'. ");
+            validationMessage.append("Your selected deck is incompatible with the '");
+            validationMessage.append(format.getName()).append("' format. ");
             if (issueCount <= 1) {
                 validationMessage.append(firstValidation);
             } else {

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/hall/HallServer.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/hall/HallServer.java
@@ -404,13 +404,20 @@ public class HallServer extends AbstractServer {
         List<String> validations = format.validateDeck(deck);
         if(!validations.isEmpty()) {
             String firstValidation = validations.stream().findFirst().orElse(null);
-            long count = firstValidation.chars().filter(x -> x == '\n').count();
+            long newLineCount = firstValidation.chars().filter(x -> x == '\n').count();
             if (firstValidation.contains("\n"))
                 firstValidation = firstValidation.substring(0, firstValidation.indexOf("\n"));
-            String validation = "Deck targets '" + deck.getTargetFormat() + "' format and is incompatible with '" +
-                    format.getName() + "'.  Issues include: `" + firstValidation + "` and " +
-                    (validations.size() - 1 + count - 1) + " other issues.";
-            throw new HallException("Your selected deck is not valid for this format: " + validation);
+            long issueCount = validations.size() + newLineCount;
+            StringBuilder validationMessage = new StringBuilder();
+            validationMessage.append("Your selected deck is not valid for this format: ");
+            validationMessage.append("Deck is incompatible with '").append(format.getName()).append("'. ");
+            if (issueCount <= 1) {
+                validationMessage.append(firstValidation);
+            } else {
+                validationMessage.append("Issues include: '").append(firstValidation).append("' and ");
+                validationMessage.append(issueCount - 1).append(" other issues.");
+            }
+            throw new HallException(validationMessage.toString());
         }
         return cardDeck;
     }


### PR DESCRIPTION
Closes #99 

Identified issue: The deck validation code was only looking at draw deck cards prior to the game starting. So, if there were any invalid blueprint id's in other subdecks, the game could still be started, and a runtime exception would be thrown when trying to create the physical card from the blueprint.

Changes made:
- Updated deck validation code to look at all cards in the deck
- Replaced the runtime exception within the game with a chat message indicating the error has been encountered. This way it won't crash the server.
- Edited the message that is sent to the hall chat when the deck can't be validated. (The error message is assembled as a list of individual error strings in DefaultGameFormat.validateDeck, and summarized in HallServer.validateUserAndDeck)

Potential improvements to this PR:
Ideally, I think the messaging constructed in DefaultGameFormat and HallServer would be more controlled by the client. I don't see this as a priority at this time, but flagging @andrewd18 for any feedback.