### PR TITLE
Region visualization

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -476,13 +476,13 @@ ul {
 
 .first-in-region {
     border-left-style: dashed;
-    border-left-width: 3px;
+    border-left-width: 2px;
     border-left-color: white;
 }
 
 .last-in-region {
     border-right-style: dashed;
-    border-right-width: 3px;
+    border-right-width: 2px;
     border-right-color: white;
 }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -474,6 +474,18 @@ ul {
     z-index: 10;
 }
 
+.first-in-region {
+    border-left-style: dashed;
+    border-left-width: 3px;
+    border-left-color: white;
+}
+
+.last-in-region {
+    border-right-style: dashed;
+    border-right-width: 3px;
+    border-right-color: white;
+}
+
 .st1e-card-group {
     z-index: 9;
 }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -211,6 +211,7 @@ export default class GameAnimations {
         var cardId = element.getAttribute("cardId");
         var zone = element.getAttribute("zone");
         var imageUrl = element.getAttribute("imageUrl");
+        let region = element.getAttribute("region");
         var quadrant = element.getAttribute("quadrant");
         var locationIndex = element.getAttribute("locationIndex");
 
@@ -224,9 +225,9 @@ export default class GameAnimations {
 
                 if (zone == "SPACELINE") {
                     if (eventType == "PUT_SHARED_MISSION_INTO_PLAY") {
-                        that.game.addSharedMission(locationIndex, quadrant);
+                        that.game.addSharedMission(locationIndex, quadrant, region);
                     } else {
-                        that.game.addLocationDiv(locationIndex, quadrant);
+                        that.game.addLocationDiv(locationIndex, quadrant, region);
                     }
                 }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -2501,7 +2501,7 @@ export class ST1EGameTableUI extends GameTableUI {
             locationDiv === undefined) {
             return "";
         }
-        switch (locationDiv.data("region")) {
+        switch (locationDiv) {
             // 1E regions
             case "ARGOLIS_CLUSTER":
                 return "Argolis Cluster Region";

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -2157,11 +2157,11 @@ export class ST1EGameTableUI extends GameTableUI {
         super(url, replayMode);
     }
 
-    addSharedMission(index, quadrant) {
+    addSharedMission(index, quadrant, region) {
         // TODO - no code here yet
     }
 
-    addLocationDiv(index, quadrant) {
+    addLocationDiv(index, quadrant, region) {
         var that = this;
 
         // Increment locationIndex for existing cards on the table to the right of the added location
@@ -2196,6 +2196,7 @@ export class ST1EGameTableUI extends GameTableUI {
         var newDiv = $("<div id='location" + index + "' class='ui-widget-content locationDiv'></div>");
         newDiv.data( "locationIndex", index);
         newDiv.data( "quadrant", quadrant);
+        newDiv.data("region", region);
         $("#main").append(newDiv);
 
         this.locationDivs.splice(index, 0, newDiv);
@@ -2379,7 +2380,7 @@ export class ST1EGameTableUI extends GameTableUI {
         for (var locationIndex = 0; locationIndex < locationsCount; locationIndex++) {
             this.locationDivs[locationIndex].css({left:x, top:y, width:locationDivWidth, height:locationDivHeight});
             var currQuadrant = this.locationDivs[locationIndex].data("quadrant");
-            if (locationIndex == 0) {
+            if (locationIndex === 0) {
                 this.locationDivs[locationIndex].addClass("first-in-quadrant");
             } else if (currQuadrant != this.locationDivs[locationIndex - 1].data("quadrant")) {
                 this.locationDivs[locationIndex].addClass("first-in-quadrant");
@@ -2387,7 +2388,7 @@ export class ST1EGameTableUI extends GameTableUI {
                 this.locationDivs[locationIndex].removeClass("first-in-quadrant");
             }
 
-            if (locationIndex == locationsCount - 1) {
+            if (locationIndex === locationsCount - 1) {
                 this.locationDivs[locationIndex].addClass("last-in-quadrant");
             } else if (currQuadrant != this.locationDivs[locationIndex + 1].data("quadrant")) {
                 this.locationDivs[locationIndex].addClass("last-in-quadrant");
@@ -2395,21 +2396,48 @@ export class ST1EGameTableUI extends GameTableUI {
                 this.locationDivs[locationIndex].removeClass("last-in-quadrant");
             }
 
-            if (currQuadrant == "ALPHA" ) {
+            let currentRegion = this.locationDivs[locationIndex].data("region");
+            let friendly_region_name = this._friendly_region_name(currentRegion);
+
+            if (currQuadrant === "ALPHA" ) {
                 this.locationDivs[locationIndex].addClass("alpha-quadrant");
-                this.locationDivs[locationIndex].attr("title", "Alpha Quadrant");
+
+                if (friendly_region_name === "") {
+                    this.locationDivs[locationIndex].attr("title", "Alpha Quadrant");
+                }
+                else {
+                    this.locationDivs[locationIndex].attr("title", `${friendly_region_name} (Alpha Quadrant)`);
+                }
             }
-            if (currQuadrant == "GAMMA" ) {
+            if (currQuadrant === "GAMMA" ) {
                 this.locationDivs[locationIndex].addClass("gamma-quadrant");
-                this.locationDivs[locationIndex].attr("title", "Gamma Quadrant");
+
+                if (friendly_region_name === "") {
+                    this.locationDivs[locationIndex].attr("title", "Gamma Quadrant");
+                }
+                else {
+                    this.locationDivs[locationIndex].attr("title", `${friendly_region_name} (Gamma Quadrant)`);
+                }
             }
-            if (currQuadrant == "DELTA" ) {
+            if (currQuadrant === "DELTA" ) {
                 this.locationDivs[locationIndex].addClass("delta-quadrant");
-                this.locationDivs[locationIndex].attr("title", "Delta Quadrant");
+                
+                if (friendly_region_name === "") {
+                    this.locationDivs[locationIndex].attr("title", "Delta Quadrant");
+                }
+                else {
+                    this.locationDivs[locationIndex].attr("title", `${friendly_region_name} (Delta Quadrant)`);
+                }
             }
-            if (currQuadrant == "MIRROR" ) {
+            if (currQuadrant === "MIRROR" ) {
                 this.locationDivs[locationIndex].addClass("mirror-quadrant");
-                this.locationDivs[locationIndex].attr("title", "Mirror Quadrant");
+                
+                if (friendly_region_name === "") {
+                    this.locationDivs[locationIndex].attr("title", "Mirror Quadrant");
+                }
+                else {
+                    this.locationDivs[locationIndex].attr("title", `${friendly_region_name} (Mirror Quadrant)`);
+                }
             }
 
             this.missionCardGroups[locationIndex].setBounds(x, y + locationDivHeight/3, locationDivWidth, locationDivHeight/3);
@@ -2447,6 +2475,62 @@ export class ST1EGameTableUI extends GameTableUI {
                 height: 97,
                 "z-index": 1000
             });
+        }
+    }
+
+    // Converts region enum sent from Region.java to a user friendly string
+    _friendly_region_name(locationDiv) {
+        if (locationDiv === null ||
+            locationDiv === undefined) {
+            return "";
+        }
+        switch (locationDiv.data("region")) {
+            // 1E regions
+            case "ARGOLIS_CLUSTER":
+                return "Argolis Cluster Region";
+            case "BADLANDS":
+                return "Badlands Region";
+            case "BAJOR":
+                return "Bajor Region";
+            case "BRIAR_PATCH":
+                return "Briar Patch Region";
+            case "CARDASSIA":
+                return "Cardassia Region";
+            case "CETI_ALPHA":
+                return "Ceti Alpha Region";
+            case "CHIN_TOKA":
+                return "Chin'toka Region";
+            case "DELPHIC_EXPANSE":
+                return "Delphic Expanse Region";
+            case "DEMILITARIZED_ZONE":
+                return "Demilitarized Zone Region";
+            case "GREAT_BARRIER":
+                return "Great Barrier Region";
+            case "MCALLISTER":
+                return "McAllister Region";
+            case "MURASAKI":
+                return "Murasaki Region";
+            case "MUTARA":
+                return "Mutara Region";
+            case "NEKRIT_EXPANSE":
+                return "Nekrit Expanse Region";
+            case "NEUTRAL_ZONE":
+                return "Neutral Zone Region";
+            case "NORTHWEST_PASSAGE":
+                return "Northwest Passage Region";
+            case "ROMULUS_SYSTEM":
+                return "Romulus System Region";
+            case "SECTOR_001":
+                return "Sector 001 Region";
+            case "TELLUN":
+                return "Tellun Region";
+            case "VALO":
+                return "Valo Region Region";
+            // 2E regions
+            case "QO_NOS_SYSTEM":
+                return "Qo'noS Region";
+            default:
+                return "";
         }
     }
 }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -2398,6 +2398,23 @@ export class ST1EGameTableUI extends GameTableUI {
 
             let currentRegion = this.locationDivs[locationIndex].data("region");
             let friendly_region_name = this._friendly_region_name(currentRegion);
+            if (friendly_region_name !== "") {
+                if (locationIndex === 0) {
+                    this.locationDivs[locationIndex].addClass("first-in-region");
+                } else if (currentRegion != this.locationDivs[locationIndex - 1].data("region")) {
+                    this.locationDivs[locationIndex].addClass("first-in-region");
+                } else if (this.locationDivs[locationIndex].hasClass("first-in-region")) {
+                    this.locationDivs[locationIndex].removeClass("first-in-region");
+                }
+    
+                if (locationIndex === locationsCount - 1) {
+                    this.locationDivs[locationIndex].addClass("last-in-region");
+                } else if (currentRegion != this.locationDivs[locationIndex + 1].data("region")) {
+                    this.locationDivs[locationIndex].addClass("last-in-region");
+                } else if (this.locationDivs[locationIndex].hasClass("last-in-region")) {
+                    this.locationDivs[locationIndex].removeClass("last-in-region");
+                }
+            }
 
             if (currQuadrant === "ALPHA" ) {
                 this.locationDivs[locationIndex].addClass("alpha-quadrant");


### PR DESCRIPTION
### Summary of Changes
Adds dashed vertical borders to the edges of regions. Shown below are two regions, one that is one card wide, one that is 2 cards wide.

![image](https://github.com/user-attachments/assets/aaf50b84-cf08-46c2-a4c6-af7102d1354a)

Updates the on-hover text to include both region and quadrant.
![image](https://github.com/user-attachments/assets/98f11c6c-a2be-4311-87bf-b2425744cb9a)

### Benefits
- Closes #71 

### Risks
- None I can think of; this is a low risk PR since it just messes with borders, no other placement.

### Testing
- Manual