### PR TITLE
Fixed card images for two cards in the Engage set

### DIFF
--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set161.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set161.hjson
@@ -15,7 +15,7 @@
             location: Inhospitable planet
             lore: Participate in tactical training scenarios in harsh environment.
             mission-requirements: Computer Skill + SECURITY + Leadership + MEDICAL
-            image-url: https://www.trekcc.org/1e/cardimages/comingofage/21.jpg
+            image-url: https://www.trekcc.org/1e/cardimages/engage/21.jpg
         }
         {
             blueprintId: 161_024
@@ -28,7 +28,7 @@
             location: Near Xendi Sabu system
             lore: 'Meet with old adversary to discuss a "gift."'
             mission-requirements: Navigation x2 + Leadership x2 + (DaiMon Bok OR Jean-Luc Picard OR INTEGRITY>30)
-            image-url: https://www.trekcc.org/1e/cardimages/comingofage/24.jpg
+            image-url: https://www.trekcc.org/1e/cardimages/engage/24.jpg
         }
         {
             blueprintId: 161_038


### PR DESCRIPTION
Straightforward fix for two cards that had the wrong image URL link.