### PR TITLE
Multiaffiliation fix

### DIFF
--- a/gemp-module/gamestate-example.hjson
+++ b/gemp-module/gamestate-example.hjson
@@ -102,7 +102,7 @@
             "cardId": 1,
             "owner": "player1",
             "zone": "AT_LOCATION",
-            "affiliation": "FEDERATION", // only included for affiliated cards
+            "affiliation": "FEDERATION", // only included for affiliated cards in play
             "locationZoneIndex": 3 // only included if the card is on the spaceline
         },
         {
@@ -113,7 +113,7 @@
             "zone": "ATTACHED",
                /* Cards in the ATTACHED zone are attached to other cards. In this case, it demonstrates
                     that this ship is docked at a facility. */
-            "affiliation": "FEDERATION", // only included for affiliated cards
+            "affiliation": "FEDERATION", // only included for affiliated cards in play
             "locationZoneIndex": 3 // only included if the card is on the spaceline
             "attachedToCardId": 1, // only included if the card is attached to another
             "dockedAtCardId": 1, // only included for a docked ship

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/modifiers/ChangeAffiliationAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/modifiers/ChangeAffiliationAction.java
@@ -28,7 +28,7 @@ public class ChangeAffiliationAction extends ActionyAction implements TopLevelSe
         super(player, "Change affiliation", ActionType.OTHER);
         _card = card;
         _card.getAffiliationOptions().forEach(affiliation -> {
-            if (affiliation != _card.getAffiliation())
+            if (affiliation != _card.getCurrentAffiliation())
                 _affiliationOptions.add(affiliation);
         });
         if (card instanceof PersonnelCard personnel) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/ReportCardAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/ReportCardAction.java
@@ -12,7 +12,6 @@ import com.gempukku.stccg.filters.Filters;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.game.Player;
-import com.gempukku.stccg.gamestate.GameState;
 import com.gempukku.stccg.gamestate.MissionLocation;
 import com.gempukku.stccg.gamestate.ST1EGameState;
 import com.google.common.collect.Iterables;
@@ -43,7 +42,7 @@ public class ReportCardAction extends STCCGPlayCardAction {
             _affiliationWasChosen = false;
         } else {
             _affiliationWasChosen = true;
-            _selectedAffiliation = cardToPlay.getAffiliation();
+            _selectedAffiliation = cardToPlay.getCurrentAffiliation();
         }
     }
 
@@ -154,7 +153,7 @@ public class ReportCardAction extends STCCGPlayCardAction {
             cardGame.sendMessage(_cardEnteringPlay.getOwnerName() + " played " + _cardEnteringPlay.getCardLink());
 
             _cardEnteringPlay.reportToFacility(_reportingDestination);
-            performingPlayer.addPlayedAffiliation(_cardEnteringPlay.getAffiliation());
+            performingPlayer.addPlayedAffiliation(_cardEnteringPlay.getCurrentAffiliation());
             cardGame.getActionsEnvironment().emitEffectResult(
                     new PlayCardResult(this, _fromZone, _cardEnteringPlay));
         }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/SeedOutpostAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/SeedOutpostAction.java
@@ -36,7 +36,7 @@ public class SeedOutpostAction extends PlayCardAction {
             _affiliationWasChosen = false;
         } else {
             _affiliationWasChosen = true;
-            _selectedAffiliation = cardToSeed.getAffiliation();
+            _selectedAffiliation = cardToSeed.getCurrentAffiliation();
         }
     }
 
@@ -106,7 +106,7 @@ public class SeedOutpostAction extends PlayCardAction {
             cardGame.sendMessage(_cardEnteringPlay.getOwnerName() + " seeded " + _cardEnteringPlay.getCardLink());
             gameState.removeCardFromZone(_cardEnteringPlay);
             gameState.getPlayer(_cardEnteringPlay.getOwnerName())
-                    .addPlayedAffiliation(_cardEnteringPlay.getAffiliation());
+                    .addPlayedAffiliation(_cardEnteringPlay.getCurrentAffiliation());
             gameState.seedFacilityAtLocation(_cardEnteringPlay, _locationZoneIndex);
             cardGame.getActionsEnvironment().emitEffectResult(
                     new PlayCardResult(this, _fromZone, _cardEnteringPlay));

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/AttemptingUnit.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/AttemptingUnit.java
@@ -19,7 +19,7 @@ public interface AttemptingUnit {
         for (PhysicalCard card : getAllPersonnel()) {
             if (card instanceof PersonnelCard personnel)
                 if (!personnel.isStopped() && !personnel.isDisabled() && !personnel.isInStasis() &&
-                        personnel.getAffiliation() != Affiliation.BORG)
+                        personnel.getCurrentAffiliation() != Affiliation.BORG)
                     personnelAttempting.add(personnel);
         }
         return personnelAttempting;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/AwayTeam.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/AwayTeam.java
@@ -37,7 +37,7 @@ public class AwayTeam implements AttemptingUnit {
     private boolean hasAffiliation(Affiliation affiliation) {
         for (PhysicalCard card : _cardsInAwayTeam) {
             if (card instanceof PhysicalNounCard1E noun)
-                if (noun.getAffiliation() == affiliation)
+                if (noun.getCurrentAffiliation() == affiliation)
                     return true;
         }
         return false;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/Blueprint155_095.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/Blueprint155_095.java
@@ -11,6 +11,6 @@ public class Blueprint155_095 extends CardBlueprint {
 
     @Override
     public boolean doesNotWorkWithPerRestrictionBox(PhysicalNounCard1E thisCard, PhysicalNounCard1E otherCard) {
-        return (otherCard.getAffiliation() == Affiliation.FEDERATION && thisCard.getCardId() != otherCard.getCardId());
+        return (otherCard.getCurrentAffiliation() == Affiliation.FEDERATION && thisCard.getCardId() != otherCard.getCardId());
     }
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AbstractPhysicalCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AbstractPhysicalCard.java
@@ -54,7 +54,7 @@ public abstract class AbstractPhysicalCard implements PhysicalCard {
         // TODO - Replace with a client communication method that pulls image options from the library
         String result;
         if (this instanceof AffiliatedCard affiliatedCard) {
-            String affiliatedImage = _blueprint.getAffiliationImageUrl(affiliatedCard.getAffiliation());
+            String affiliatedImage = _blueprint.getAffiliationImageUrl(affiliatedCard.getCurrentAffiliation());
             if (affiliatedImage != null)
                 result = affiliatedImage;
             else

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AffiliatedCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AffiliatedCard.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public interface AffiliatedCard extends PhysicalCard {
     ST1EGame getGame();
     boolean isMultiAffiliation();
-    Affiliation getAffiliation();
+    Affiliation getCurrentAffiliation();
     void setCurrentAffiliation(Affiliation affiliation);
     void changeAffiliation(Affiliation affiliation) throws InvalidGameLogicException;
     Set<Affiliation> getAffiliationOptions();

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/FacilityCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/FacilityCard.java
@@ -1,6 +1,5 @@
 package com.gempukku.stccg.cards.physicalcard;
 
-import com.gempukku.stccg.actions.Action;
 import com.gempukku.stccg.actions.TopLevelSelectableAction;
 import com.gempukku.stccg.actions.movecard.BeamCardsAction;
 import com.gempukku.stccg.actions.movecard.WalkCardsAction;
@@ -68,7 +67,7 @@ public class FacilityCard extends PhysicalNounCard1E implements AffiliatedCard, 
         if (playerId.equals(_owner.getPlayerId()))
             return true;
         return getFacilityType() == FacilityType.HEADQUARTERS &&
-                _game.getGameState().getPlayer(playerId).isPlayingAffiliation(getAffiliation());
+                _game.getGameState().getPlayer(playerId).isPlayingAffiliation(getCurrentAffiliation());
     }
 
     public boolean isUsableBy(String playerId) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCardDeserializer.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCardDeserializer.java
@@ -17,7 +17,7 @@ public class PhysicalCardDeserializer {
         Zone zone = Zone.valueOf(node.get("zone").textValue());
         card.setZone(zone);
 
-        if (card instanceof AffiliatedCard affiliatedCard) {
+        if (card instanceof AffiliatedCard affiliatedCard && node.has("affiliation")) {
             Affiliation affiliation = Affiliation.valueOf(node.get("affiliation").textValue());
             affiliatedCard.setCurrentAffiliation(affiliation);
         }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCardSerializer.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCardSerializer.java
@@ -32,8 +32,8 @@ public class PhysicalCardSerializer extends StdSerializer<PhysicalCard> {
         if (physicalCard.getLocationZoneIndex() >= 0)
             jsonGenerator.writeNumberField("locationZoneIndex", physicalCard.getLocationZoneIndex());
 
-        if (physicalCard instanceof AffiliatedCard affiliatedCard)
-            jsonGenerator.writeStringField("affiliation", affiliatedCard.getAffiliation().name());
+        if (physicalCard instanceof AffiliatedCard affiliatedCard && physicalCard.isInPlay())
+            jsonGenerator.writeStringField("affiliation", affiliatedCard.getCurrentAffiliation().name());
         if (physicalCard instanceof PhysicalReportableCard1E reportable)
             jsonGenerator.writeBooleanField("isStopped", reportable.isStopped());
         if (physicalCard instanceof PhysicalShipCard shipCard) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalNounCard1E.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalNounCard1E.java
@@ -21,7 +21,7 @@ public class PhysicalNounCard1E extends ST1EPhysicalCard {
 
     protected Quadrant getNativeQuadrant() { return _blueprint.getQuadrant(); }
     public boolean isMultiAffiliation() { return getAffiliationOptions().size() > 1; }
-    public Affiliation getAffiliation() { return _currentAffiliation; }
+    public Affiliation getCurrentAffiliation() { return _currentAffiliation; }
 
     public void setCurrentAffiliation(Affiliation affiliation) {
         _currentAffiliation = affiliation;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalShipCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalShipCard.java
@@ -162,7 +162,7 @@ public class PhysicalShipCard extends PhysicalReportableCard1E
             boolean matchesShip = false;
             boolean matchesMission = false;
             for (PersonnelCard card : getAttemptingPersonnel()) {
-                Affiliation personnelAffiliation = card.getAffiliation();
+                Affiliation personnelAffiliation = card.getCurrentAffiliation();
                 if (personnelAffiliation == _currentAffiliation)
                     matchesShip = true;
                 if (mission.getAffiliationIcons(_owner.getPlayerId()).contains(personnelAffiliation))

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/Filters.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/Filters.java
@@ -186,10 +186,10 @@ public class Filters {
             List<Affiliation> filteredAffiliations = new LinkedList<>();
             if (cardToMatch.getZone().isInPlay())
                 affiliationsToMatch.addAll(cardToMatch.getBlueprint().getAffiliations());
-            else affiliationsToMatch.add(((PhysicalNounCard1E) cardToMatch).getAffiliation());
+            else affiliationsToMatch.add(((PhysicalNounCard1E) cardToMatch).getCurrentAffiliation());
             if (physicalCard.getZone().isInPlay())
                 filteredAffiliations.addAll(physicalCard.getBlueprint().getAffiliations());
-            else filteredAffiliations.add(((PhysicalNounCard1E) physicalCard).getAffiliation());
+            else filteredAffiliations.add(((PhysicalNounCard1E) physicalCard).getCurrentAffiliation());
             for (Affiliation matchAffiliation : affiliationsToMatch)
                 for (Affiliation filterAffiliation : filteredAffiliations)
                     if (matchAffiliation == filterAffiliation)

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1ERuleSet.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1ERuleSet.java
@@ -29,8 +29,8 @@ public class ST1ERuleSet extends RuleSet {
         if (card1.getCardType() == CardType.EQUIPMENT || card2.getCardType() == CardType.EQUIPMENT)
             return true;
         else if (card1 instanceof AffiliatedCard affiliatedCard1 && card2 instanceof AffiliatedCard affiliatedCard2) {
-            Affiliation affil1 = affiliatedCard1.getAffiliation();
-            Affiliation affil2 = affiliatedCard2.getAffiliation();
+            Affiliation affil1 = affiliatedCard1.getCurrentAffiliation();
+            Affiliation affil2 = affiliatedCard2.getCurrentAffiliation();
             if (affil1 == affil2) {
                 return true;
             } else if (affil1 == Affiliation.BORG || affil2 == Affiliation.BORG) {


### PR DESCRIPTION
Should close #131 

Bug fix. Gamestate was not being successfully created if the deck included multi-affiliation cards, since they have multiple affiliations while not in play.

Since affiliation of a card not in play can be determined directly from the blueprint (and I don't believe the client needs this information), removing the "affiliation" field from cards in the serialized gamestate unless they are in play.