### PR TITLE
AMS Fix

### DIFF
--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/choose/SelectValidCardCombinationFromDialogAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/choose/SelectValidCardCombinationFromDialogAction.java
@@ -1,0 +1,74 @@
+package com.gempukku.stccg.actions.choose;
+
+import com.gempukku.stccg.actions.Action;
+import com.gempukku.stccg.actions.ActionyAction;
+import com.gempukku.stccg.cards.ActionContext;
+import com.gempukku.stccg.cards.physicalcard.FacilityCard;
+import com.gempukku.stccg.cards.physicalcard.PersonnelCard;
+import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
+import com.gempukku.stccg.common.DecisionResultInvalidException;
+import com.gempukku.stccg.common.filterable.FacilityType;
+import com.gempukku.stccg.decisions.ArbitraryCardsSelectionDecision;
+import com.gempukku.stccg.decisions.AwaitingDecision;
+import com.gempukku.stccg.filters.Filter;
+import com.gempukku.stccg.filters.Filters;
+import com.gempukku.stccg.game.DefaultGame;
+import com.gempukku.stccg.game.InvalidGameLogicException;
+import com.gempukku.stccg.game.Player;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class SelectValidCardCombinationFromDialogAction extends ActionyAction implements SelectCardsAction {
+    private final Collection<? extends PhysicalCard> _selectableCards;
+    private final static int MINIMUM = 0;
+    private final Map<PersonnelCard, List<PersonnelCard>> _validCombinations;
+    private final int _maximum;
+    private final String _choiceText;
+    private Collection<PhysicalCard> _selectedCards;
+
+    public SelectValidCardCombinationFromDialogAction(Player performingPlayer, String choiceText,
+                                                      Collection<PhysicalCard> selectableCards,
+                                                      Map<PersonnelCard, List<PersonnelCard>> validCombinations,
+                                                      int maximum) {
+        super(performingPlayer, choiceText, ActionType.SELECT_CARD);
+        _selectableCards = selectableCards;
+        _maximum = maximum;
+        _validCombinations = validCombinations;
+        _choiceText = choiceText;
+    }
+
+
+    public boolean requirementsAreMet(DefaultGame game) {
+        return !_selectableCards.isEmpty();
+    }
+
+    @Override
+    public Action nextAction(DefaultGame cardGame) throws InvalidGameLogicException {
+        Player performingPlayer = cardGame.getPlayer(_performingPlayerId);
+        AwaitingDecision decision = new ArbitraryCardsSelectionDecision(performingPlayer, _choiceText,
+                _selectableCards, _validCombinations, MINIMUM, _maximum) {
+            @Override
+            public void decisionMade(String result) throws DecisionResultInvalidException {
+                _selectedCards = getSelectedCardsByResponse(result);
+                _wasCarriedOut = true;
+            }
+        };
+
+        cardGame.getUserFeedback().sendAwaitingDecision(decision);
+
+        return getNextAction();
+    }
+
+    @Override
+    public boolean wasCarriedOut() {
+        return _wasCarriedOut;
+    }
+
+    @Override
+    public Collection<PhysicalCard> getSelectedCards() {
+        return _selectedCards;
+    }
+}

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
@@ -1,14 +1,17 @@
 package com.gempukku.stccg.cards.blueprints;
 
 import com.gempukku.stccg.AbstractAtTest;
+import com.gempukku.stccg.cards.physicalcard.FacilityCard;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
 import com.gempukku.stccg.common.DecisionResultInvalidException;
 import com.gempukku.stccg.common.filterable.Phase;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Blueprint_109_063_AMS_Test extends AbstractAtTest {
 
@@ -18,24 +21,42 @@ public class Blueprint_109_063_AMS_Test extends AbstractAtTest {
         autoSeedMissions();
 
         PhysicalCard ams = null;
-        PhysicalCard fedOutpost = null;
+        FacilityCard fedOutpost = null;
+        PhysicalCard wallace = null;
+        PhysicalCard tarses = null;
 
         for (PhysicalCard card : _game.getGameState().getAllCardsInGame()) {
             if (Objects.equals(card.getTitle(), "Assign Mission Specialists"))
                 ams = card;
             if (Objects.equals(card.getTitle(), "Federation Outpost"))
-                fedOutpost = card;
+                fedOutpost = (FacilityCard) card;
+            if (Objects.equals(card.getTitle(), "Darian Wallace"))
+                wallace = card;
+            if (Objects.equals(card.getTitle(), "Simon Tarses"))
+                tarses = card;
         }
 
         assertNotNull(ams);
         assertNotNull(fedOutpost);
+        assertNotNull(tarses);
+        assertNotNull(wallace);
         while (_game.getCurrentPhase() == Phase.SEED_DILEMMA) {
             skipDilemma();
         }
 
         seedCard(P1, fedOutpost);
         seedCard(P1, ams);
+        playerDecided(P1, "0");
         assertNotNull(_userFeedback.getAwaitingDecision(P1));
+
+        List<PhysicalCard> specialists = List.of(tarses, wallace);
+
+        selectCards(P1, specialists);
+        for (PhysicalCard specialist : specialists) {
+            assertTrue(specialist.isInPlay());
+            assertTrue(fedOutpost.getCrew().contains(specialist));
+        }
+//        assertNotNull(_userFeedback.getAwaitingDecision(P1));
     }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
@@ -56,7 +56,6 @@ public class Blueprint_109_063_AMS_Test extends AbstractAtTest {
             assertTrue(specialist.isInPlay());
             assertTrue(fedOutpost.getCrew().contains(specialist));
         }
-//        assertNotNull(_userFeedback.getAwaitingDecision(P1));
     }
 
 }


### PR DESCRIPTION
Closes #141 

The download action for AMS was jumping to identify compatible reporting destinations before identifying the cards that were being downloaded. Fixed by adding a new SelectCardsAction for this type of "valid combinations" selection and restructuring the AMS download action to use that instead of a raw Decision object.

Also added some additional checks into the AMS unit test.

No concerns that this breaks anything more than it was already broken on my end, so I'm going to push this.