### PR TITLE
Ship report fix

### DIFF
--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalShipCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalShipCard.java
@@ -64,10 +64,8 @@ public class PhysicalShipCard extends PhysicalReportableCard1E
 
     @Override
     public void reportToFacility(FacilityCard facility) throws InvalidGameLogicException {
-        setLocation(facility.getLocation()); // TODO - What happens if the facility doesn't allow docking?
-        _game.getGameState().attachCard(this, facility);
-        _docked = true;
-        _dockedAtCard = facility;
+        super.reportToFacility(facility);
+        dockAtFacility(facility);
     }
 
     public void dockAtFacility(FacilityCard facilityCard) {


### PR DESCRIPTION
Fixed bug in reporting ships. Closes #144 

After a recent PR, PhysicalShipCard was no longer being removed from its zone before being reported to a facility. Now calling the supertype's reportToFacility() method, so that all reportable cards will use the same code for reporting.