### PR TITLE
Away team fix

### DIFF
--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/choose/SelectAttemptingUnitAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/choose/SelectAttemptingUnitAction.java
@@ -21,9 +21,10 @@ public class SelectAttemptingUnitAction extends ActionyAction {
     private final List<AttemptingUnit> _eligibleUnits;
     private AttemptingUnit _selectedResponse;
 
-    public SelectAttemptingUnitAction(DefaultGame cardGame, Player player, Collection<AttemptingUnit> attemptingUnits)
+    public SelectAttemptingUnitAction(DefaultGame cardGame, Player player, Collection<AttemptingUnit> attemptingUnits,
+                                      String selectionText)
             throws InvalidGameLogicException {
-        super(cardGame, player, "Choose an Away Team", ActionType.SELECT_AWAY_TEAM);
+        super(cardGame, player, selectionText, ActionType.SELECT_AWAY_TEAM);
         _eligibleUnits = new LinkedList<>(attemptingUnits);
         for (AttemptingUnit unit : _eligibleUnits) {
             String decisionText;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/AttemptMissionAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/AttemptMissionAction.java
@@ -84,8 +84,9 @@ public class AttemptMissionAction extends ActionyAction implements TopLevelSelec
                             eligibleUnits.add(ship);
                 }
                 if (eligibleUnits.size() > 1) {
-                    _attemptingUnitTarget =
-                            new AttemptingUnitResolver(new SelectAttemptingUnitAction(cardGame, player, eligibleUnits));
+                    String selectionText = (_missionLocation.isPlanet()) ? "Choose an Away Team" : "Choose a ship";
+                    _attemptingUnitTarget = new AttemptingUnitResolver(
+                            new SelectAttemptingUnitAction(cardGame, player, eligibleUnits, selectionText));
                     return _attemptingUnitTarget.getSelectionAction();
                 } else {
                     _attemptingUnitTarget = new AttemptingUnitResolver(Iterables.getOnlyElement(eligibleUnits));

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/movecard/BeamOrWalkAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/movecard/BeamOrWalkAction.java
@@ -146,8 +146,8 @@ public abstract class BeamOrWalkAction extends ActionyAction implements TopLevel
                 card.setLocation(destinationLocation);
                 if (_origin instanceof MissionCard)
                     ((PhysicalReportableCard1E) card).leaveAwayTeam((ST1EGame) cardGame);
-                if (destinationLocation instanceof MissionLocation missionLocation)
-                    ((PhysicalReportableCard1E) card).joinEligibleAwayTeam(missionLocation);
+                if (_destination instanceof MissionCard && destinationLocation instanceof MissionLocation mission)
+                    ((PhysicalReportableCard1E) card).joinEligibleAwayTeam(mission);
             }
             if (!_cardsToMove.isEmpty()) {
                 cardGame.sendMessage(_performingPlayerId + " " + actionVerb() + "ed " +

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_010_Maglock_Test.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_010_Maglock_Test.java
@@ -76,6 +76,7 @@ public class Blueprint_109_010_Maglock_Test extends AbstractAtTest {
             assertTrue(runabout.getCrew().contains(card));
             assertFalse(_outpost.getCrew().contains(card));
         }
+        assertEquals(0, _game.getGameState().getAwayTeams().size());
 
         undockShip(P1, runabout);
         assertFalse(runabout.isDocked());
@@ -140,6 +141,7 @@ public class Blueprint_109_010_Maglock_Test extends AbstractAtTest {
             assertTrue(runabout.getCrew().contains(card));
             assertFalse(_outpost.getCrew().contains(card));
         }
+        assertEquals(0, _game.getGameState().getAwayTeams().size());
 
         undockShip(P1, runabout);
         assertFalse(runabout.isDocked());


### PR DESCRIPTION
Resolves #160

Fixed a bug where Away Teams were created when personnel and equipment were beamed between ships and facilities. Also updated selection text on SelectAttemptingUnit action to show "Choose a ship" for a space mission.

Added logic in the Maglock unit test to check that no Away Teams are created when cards are beamed around in space.