### PR TITLE
Fix undefined references in gameAnimations.js

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -1,5 +1,5 @@
 import Card from "./jCards.js";
-import { getCardDivFromId } from "./jCards.js";
+import { getCardDivFromId, createSimpleCardDiv } from "./jCards.js";
 import { layoutCardElem } from "./jCardGroup.js";
 
 export default class GameAnimations {
@@ -28,14 +28,14 @@ export default class GameAnimations {
         if (animate) {
             var that = this;
 
-            var participantId = json.participantId;
-            var cardId = json.cardId;
+            let participantId = json.participantId;
+            let cardId = json.cardId;
 
             // Play-out game event animation only if it's not the player who initiated it
             if (this.game.spectatorMode || this.game.replayMode || (participantId != this.game.bottomPlayerId)) {
                 $("#main").queue(
                     function (next) {
-                        var cardDiv = getCardDivFromId(cardId);
+                        let cardDiv = getCardDivFromId(cardId);
                         if (cardDiv.length > 0) {
                             $(".borderOverlay", cardDiv)
                                 .switchClass("borderOverlay", "highlightBorderOverlay", that.getAnimationLength(that.cardActivatedDuration / 6))
@@ -57,25 +57,25 @@ export default class GameAnimations {
         if (animate) {
             var that = this;
 
-            var participantId = element.getAttribute("participantId");
-            var blueprintId = element.getAttribute("blueprintId");
-            var imageUrl = element.getAttribute("imageUrl");
+            let participantId = element.getAttribute("participantId");
+            let blueprintId = element.getAttribute("blueprintId");
+            let imageUrl = element.getAttribute("imageUrl");
 
             // Play-out game event animation only if it's not the player who initiated it
             if (this.game.spectatorMode || this.game.replayMode || (participantId != this.game.bottomPlayerId)) {
-                var card = new Card(blueprintId, "ANIMATION", "anim", participantId, imageUrl);
-                var cardDiv = createSimpleCardDiv(card.imageUrl);
+                let card = new Card(blueprintId, "ANIMATION", "anim", participantId, imageUrl);
+                let cardDiv = createSimpleCardDiv(card.imageUrl);
 
                 $("#main").queue(
                     function (next) {
                         cardDiv.data("card", card);
                         $("#main").append(cardDiv);
 
-                        var gameWidth = $("#main").width();
-                        var gameHeight = $("#main").height();
+                        let gameWidth = $("#main").width();
+                        let gameHeight = $("#main").height();
 
-                        var cardHeight = (gameHeight / 2);
-                        var cardWidth = card.getWidthForHeight(cardHeight);
+                        let cardHeight = (gameHeight / 2);
+                        let cardWidth = card.getWidthForHeight(cardHeight);
 
                         $(cardDiv).css(
                             {
@@ -125,34 +125,34 @@ export default class GameAnimations {
         if (animate) {
             var that = this;
 
-            var participantId = element.getAttribute("participantId");
-            var blueprintId = element.getAttribute("blueprintId");
-            var imageUrl = element.getAttribute("imageUrl");
-            var targetCardIds = element.getAttribute("otherCardIds").split(",");
+            let participantId = element.getAttribute("participantId");
+            let blueprintId = element.getAttribute("blueprintId");
+            let imageUrl = element.getAttribute("imageUrl");
+            let targetCardIds = element.getAttribute("otherCardIds").split(",");
 
             // Play-out card affects card animation only if it's not the player who initiated it
             if (this.game.spectatorMode || this.game.replayMode || this.game.replayMode || (participantId != this.game.bottomPlayerId)) {
                 $("#main").queue(
                     function (next) {
-                        for (var i = 0; i < targetCardIds.length; i++) {
-                            var targetCardId = targetCardIds[i];
+                        for (let i = 0; i < targetCardIds.length; i++) {
+                            let targetCardId = targetCardIds[i];
 
-                            var card = new Card(blueprintId, "ANIMATION", "anim" + i, participantId, imageUrl);
-                            var cardDiv = createSimpleCardDiv(card.imageUrl);
+                            let card = new Card(blueprintId, "ANIMATION", "anim" + i, participantId, imageUrl);
+                            let cardDiv = createSimpleCardDiv(card.imageUrl);
 
-                            var targetCard = getCardDivFromId(targetCardId);
+                            let targetCard = getCardDivFromId(targetCardId);
                             if (targetCard.length > 0) {
                                 cardDiv.data("card", card);
                                 $("#main").append(cardDiv);
 
                                 targetCard = targetCard[0];
-                                var targetCardWidth = $(targetCard).width();
-                                var targetCardHeight = $(targetCard).height();
+                                let targetCardWidth = $(targetCard).width();
+                                let targetCardHeight = $(targetCard).height();
 
-                                var shadowStartPosX;
-                                var shadowStartPosY;
-                                var shadowWidth;
-                                var shadowHeight;
+                                let shadowStartPosX;
+                                let shadowStartPosY;
+                                let shadowWidth;
+                                let shadowHeight;
                                 if (card.horizontal != $(targetCard).data("card").horizontal) {
                                     shadowWidth = targetCardHeight;
                                     shadowHeight = targetCardWidth;
@@ -194,7 +194,7 @@ export default class GameAnimations {
                     function (next) {
                         $(".card").each(
                             function () {
-                                var cardData = $(this).data("card");
+                                let cardData = $(this).data("card");
                                 if (cardData.zone == "ANIMATION") {
                                     $(this).remove();
                                 }
@@ -207,21 +207,22 @@ export default class GameAnimations {
     }
 
     putCardIntoPlay(json, animate, eventType) {
-        var participantId = json.participantId;
-        var cardId = json.cardId;
-        var zone = json.zone;
-        var imageUrl = json.imageUrl;
+        let participantId = json.participantId;
+        let cardId = json.cardId;
+        let zone = json.zone;
+        let imageUrl = json.imageUrl;
         let region = json.region;
-        var quadrant = json.quadrant;
-        var locationIndex = json.locationIndex;
+        let quadrant = json.quadrant;
+        let locationIndex = json.locationIndex;
 
         var that = this;
         $("#main").queue(
             function (next) {
-                var blueprintId = json.blueprintId;
-                var imageUrl = json.imageUrl;
-                var targetCardId = json.targetCardId;
-                var controllerId = json.controllerId;
+                let blueprintId = json.blueprintId;
+                let imageUrl = json.imageUrl;
+                let targetCardId = json.targetCardId;
+                let controllerId = json.controllerId;
+                let upsideDown;
 
                 if (zone == "SPACELINE") {
                     if (eventType == "PUT_SHARED_MISSION_INTO_PLAY") {
@@ -246,13 +247,13 @@ export default class GameAnimations {
                 if (visible_opponent_zones.includes(zone) &&
                     (participantId != that.game.bottomPlayerId)
                 ) {
-                    var upsideDown = true;
+                    upsideDown = true;
                 } else {
-                    var upsideDown = false;
+                    upsideDown = false;
                 }
 
-                var card = new Card(blueprintId, zone, cardId, participantId, imageUrl, locationIndex, upsideDown);
-                var cardDiv = that.game.createCardDivWithData(card, null);
+                let card = new Card(blueprintId, zone, cardId, participantId, imageUrl, locationIndex, upsideDown);
+                let cardDiv = that.game.createCardDivWithData(card, null);
 
                 if (zone == "DISCARD")
                     that.game.discardPileDialogs[participantId].append(cardDiv);
@@ -280,15 +281,15 @@ export default class GameAnimations {
 
         if (animate && (this.game.spectatorMode || this.game.replayMode || (participantId != this.game.bottomPlayerId))
             && zone != "DISCARD" && zone != "HAND" && zone != "DRAW_DECK") {
-            var final_position = {};
+            let final_position = {};
 
             $("#main").queue(
                 // Display the card in the center of the screen
                 function (next) {
                     // Calculate expected final position.
-                    var cardDiv = getCardDivFromId(cardId);
-                    var card = cardDiv.data("card");
-                    var pos = cardDiv.position();
+                    let cardDiv = getCardDivFromId(cardId);
+                    let card = cardDiv.data("card");
+                    let pos = cardDiv.position();
                     let card_img = $(cardDiv).children(".card_img").first();
 
                     final_position["left"] = pos.left;
@@ -305,11 +306,11 @@ export default class GameAnimations {
                     
 
                     // Now we begin the animation
-                    var gameWidth = $("#main").width();
-                    var gameHeight = $("#main").height();
+                    let gameWidth = $("#main").width();
+                    let gameHeight = $("#main").height();
 
-                    var cardHeight = (gameHeight / 2);
-                    var cardWidth = card.getWidthForHeight(cardHeight);
+                    let cardHeight = (gameHeight / 2);
+                    let cardWidth = card.getWidthForHeight(cardHeight);
 
                     $(cardDiv).css(
                         {
@@ -342,7 +343,7 @@ export default class GameAnimations {
                 }).queue(
                 function (next) {
                     // Animate the card towards the final position on the play mat.
-                    var cardDiv = getCardDivFromId(cardId);
+                    let cardDiv = getCardDivFromId(cardId);
                     $(cardDiv).animate(
                         // properties
                         {
@@ -365,7 +366,7 @@ export default class GameAnimations {
                     //       token overlay display correctly after the animation.
                     //       This may not be necessary if the overlays are contained inside the
                     //       cardDiv that is being animated, as opposed to applied in layoutCardElem.
-                    var cardDiv = getCardDivFromId(cardId);
+                    let cardDiv = getCardDivFromId(cardId);
                     let card_img = $(cardDiv).children(".card_img").first();
                     layoutCardElem(cardDiv,
                         final_position["left"],
@@ -385,11 +386,11 @@ export default class GameAnimations {
     updateCardImage(json) {
             $("#main").queue(
                 function (next) {
-                    var cardId = json.cardId;
-                    var imageUrl = json.imageUrl;
-                    var cardDiv = getCardDivFromId(cardId);
-                    images = document.getElementsByClassName("card_img_"+cardId);
-                    for (var i = 0; i < images.length; i++) {
+                    let cardId = json.cardId;
+                    let imageUrl = json.imageUrl;
+                    let cardDiv = getCardDivFromId(cardId);
+                    let images = document.getElementsByClassName("card_img_"+cardId);
+                    for (let i = 0; i < images.length; i++) {
                         images[i].src = imageUrl;
                     }
                     if (cardDiv.data("card") != null)
@@ -403,17 +404,17 @@ export default class GameAnimations {
         $("#main").queue(
             function (next) {
                 that.cardId = json.cardId;
-                var zone = json.zone;
-                var targetCardId = json.targetCardId;
-                var participantId = json.participantId;
-                var controllerId = json.controllerId;
-                var locationIndex = json.locationIndex;
+                let zone = json.zone;
+                let targetCardId = json.targetCardId;
+                let participantId = json.participantId;
+                let controllerId = json.controllerId;
+                let locationIndex = json.locationIndex;
 
                 if (controllerId != null)
                     participantId = controllerId;
 
-                var card = getCardDivFromId(that.cardId);
-                var cardData = card.data("card");
+                let card = getCardDivFromId(that.cardId);
+                let cardData = card.data("card");
                 cardData.oldGroup = that.game.getReorganizableCardGroupForCardData(cardData);
                 if (cardData.zone == "ATTACHED")
                     cardData.oldGroup = that.game.getReorganizableCardGroupForCardData(cardData.attachedToCard);
@@ -423,8 +424,6 @@ export default class GameAnimations {
                 // Remove from where it was already attached
                 that.removeFromAttached(that.cardId);
 
-                var card = getCardDivFromId(that.cardId);
-                var cardData = card.data("card");
                 // move to new zone
                 cardData.zone = zone;
                 cardData.owner = participantId;
@@ -447,8 +446,8 @@ export default class GameAnimations {
 
     removeCardFromPlay(json, animate) {
         var that = this;
-        var cardRemovedIds = json.otherCardIds.split(",");
-        var participantId = json.participantId;
+        let cardRemovedIds = json.otherCardIds.split(",");
+        let participantId = json.participantId;
 
         if (animate && (this.game.spectatorMode || this.game.replayMode || (participantId != this.game.bottomPlayerId))) {
             $("#main").queue(
@@ -466,14 +465,14 @@ export default class GameAnimations {
         }
         $("#main").queue(
             function (next) {
-                for (var i = 0; i < cardRemovedIds.length; i++) {
-                    var cardId = cardRemovedIds[i];
-                    var card = getCardDivFromId(cardId);
+                for (let i = 0; i < cardRemovedIds.length; i++) {
+                    let cardId = cardRemovedIds[i];
+                    let card = getCardDivFromId(cardId);
 
                     if (card.length > 0) {
-                        var cardData = card.data("card");
+                        let cardData = card.data("card");
                         if (cardData.zone == "ATTACHED") {
-                            removeFromAttached(cardId);
+                            that.removeFromAttached(cardId);
                         }
 
                         card.remove();
@@ -496,7 +495,7 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var phase = json.phase;
+                let phase = json.phase;
                 $("#currentPhase").text(phase);
                 next();
             });
@@ -506,7 +505,7 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var message = json.tribbleSequence;
+                let message = json.tribbleSequence;
                 // if the TribbleSequence object exists, checked via length (lol jQuery), fill it with the phase.
                 if ($("#tribbleSequence").length ) {
                     $("#tribbleSequence").html("Next Tribble in sequence:<b>" + message + "</b>");
@@ -519,8 +518,8 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var playerId = json.participantId;
-                var playerIndex = that.game.getPlayerIndex(playerId);
+                let playerId = json.participantId;
+                let playerIndex = that.game.getPlayerIndex(playerId);
                 that.game.currentPlayerId = playerId;
                 $(".player").each(function (index) {
                     if (index == playerIndex)
@@ -542,13 +541,13 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var participantId = json.participantId;
-                var score = json.score;
+                let participantId = json.participantId;
+                let score = json.score;
 
                 if (that.game.playerScores == null)
                     that.game.playerScores = new Array();
 
-                var index = that.game.getPlayerIndex(participantId);
+                let index = that.game.getPlayerIndex(participantId);
                 that.game.playerScores[index] = score;
 
                 next();
@@ -559,15 +558,15 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var playerZones = json.playerZones;
-                for (var i = 0; i < playerZones.length; i++) {
-                    var playerZone = playerZones[i];
+                let playerZones = json.playerZones;
+                for (let i = 0; i < playerZones.length; i++) {
+                    let playerZone = playerZones[i];
 
-                    var playerId = playerZone.playerId;
-                    var hand = playerZone.hand;
-                    var discard = playerZone.discard;
-                    var deck = playerZone.drawDeck;
-                    var removed = playerZone.removed;
+                    let playerId = playerZone.playerId;
+                    let hand = playerZone.hand;
+                    let discard = playerZone.discard;
+                    let deck = playerZone.drawDeck;
+                    let removed = playerZone.removed;
 
                     $("#deck" + that.game.getPlayerIndex(playerId)).text(deck);
                     $("#hand" + that.game.getPlayerIndex(playerId)).text(hand);
@@ -575,11 +574,11 @@ export default class GameAnimations {
                     $("#removedPile" + that.game.getPlayerIndex(playerId)).text(removed);
                 }
 
-                var playerScores = json.playerScores;
-                for (var i = 0; i < playerScores.length; i++) {
-                    var playerScore = playerScores[i];
-                    var playerId = playerScore.playerId;
-                    var score = playerScore.score;
+                let playerScores = json.playerScores;
+                for (let i = 0; i < playerScores.length; i++) {
+                    let playerScore = playerScores[i];
+                    let playerId = playerScore.playerId;
+                    let score = playerScore.score;
 
                     $("#score" + that.game.getPlayerIndex(playerId)).text("SCORE " + Number(score).toLocaleString("en-US"));
                 }
@@ -616,7 +615,7 @@ export default class GameAnimations {
         var that = this;
         $("#main").queue(
             function (next) {
-                var decisionType = decision.decisionType;
+                let decisionType = decision.decisionType;
                 if (decisionType === "INTEGER") {
                     that.game.integerDecision(decision);
                 } else if (decisionType === "MULTIPLE_CHOICE") {
@@ -680,9 +679,9 @@ export default class GameAnimations {
             // TODO - This can probably be greatly simplified now that "attachedToCard" has been created, but not messing with it for now
         $(".card").each(
             function () {
-                var cardData = $(this).data("card");
-                var index = -1;
-                for (var i = 0; i < cardData.attachedCards.length; i++)
+                let cardData = $(this).data("card");
+                let index = -1;
+                for (let i = 0; i < cardData.attachedCards.length; i++)
                     if (cardData.attachedCards[i].data("card").cardId == cardId) {
                         index = i;
                         break;
@@ -696,7 +695,7 @@ export default class GameAnimations {
     }
 
     attachCardDivToTargetCardId(cardDiv, targetCardId) {
-        var targetCardData = getCardDivFromId(targetCardId).data("card");
+        let targetCardData = getCardDivFromId(targetCardId).data("card");
         targetCardData.attachedCards.push(cardDiv);
         cardDiv.data("card").attachedToCard = targetCardData;
     }


### PR DESCRIPTION
### Summary of Changes
- Remove most vars, replace with lets. Remaining vars are for that=this calls which I assume JQ wants as global.
- Fix 3 undefined reference calls that crashed the UI.
  - createSimpleCardDiv was called (2x) but not imported
  - A removeFromAttached call needed a that. in front of it.

### Benefits
- Fewer UI crashes.