### PR TITLE
Only throwing errors from errorCheck if the XMLHttpRequest is done

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -9,11 +9,14 @@ export default class GempClientCommunication {
     errorCheck(errorMap) {
         var that = this;
         return function (xhr, status, request) {
-            var errorStatus = "" + xhr.status;
-            if (errorMap != null && errorMap[errorStatus] != null)
-                errorMap[errorStatus](xhr, status, request);
-            else if (""+xhr.status != "200")
-                that.failure(xhr, status, request);
+            if (xhr.readyState === 4) { // Don't throw errors unless the XMLHttpRequest is done
+                let errorStatus = "" + xhr.status;
+                if (errorMap != null && errorMap[errorStatus] != null) {
+                    errorMap[errorStatus](xhr, status, request);
+                } else if (""+xhr.status != "200") {
+                    that.failure(xhr, status, request);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
What it says on the tin.

See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState for documentation on the xhr readyState property.

This has removed the server communication error message that pops up when refreshing the hall and joining a game.