### PR TITLE
Fix quadrant background colors and region tooltips

### DIFF
--- a/gemp-module/gamestate-example.hjson
+++ b/gemp-module/gamestate-example.hjson
@@ -149,7 +149,7 @@
         {
             "locationId": 2,
             "quadrant": "ALPHA",
-            "region": "Romulus System", // There will not be a region item if the location is not in one
+            "region": "ROMULUS_SYSTEM", // There will not be a region item if the location is not in one
             "locationName": "Romulus",
             "isCompleted": false,
             "isHomeworld": true,

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -88,7 +88,7 @@ export function animateActionResult(jsonAction, jsonGameState, gameAnimations) {
                 let spacelineLocation = jsonGameState.spacelineLocations[spacelineIndex];
                 let missionCards = spacelineLocation.missionCardIds;
                 let firstMissionAtLocation = (missionCards[0] == targetCard.cardId);
-                gameAnimations.putMissionIntoPlay(targetCard, true, spacelineIndex, firstMissionAtLocation);
+                gameAnimations.putMissionIntoPlay(targetCard, true, spacelineLocation, spacelineIndex, firstMissionAtLocation);
             } else {
                 gameAnimations.putNonMissionIntoPlay(targetCard, jsonAction.performingPlayerId, jsonGameState, spacelineIndex, true);
             }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -264,15 +264,15 @@ export default class GameAnimations {
             });
     }
 
-    putMissionIntoPlay(cardJson, animate, spacelineIndex, firstMissionAtLocation) {
+    putMissionIntoPlay(cardJson, animate, spacelineLocation, spacelineIndex, firstMissionAtLocation) {
         // int spacelineIndex: index of mission's location in game state spaceline array
         // boolean firstMissionAtLocation: true if bottom or only mission card; false if card is in top of another mission card
         console.log("Calling putMissionIntoPlay");
         console.log(cardJson);
         console.log(spacelineIndex);
         var that = this;
-        let region = cardJson.region;
-        let quadrant = cardJson.quadrant;
+        let region = spacelineLocation.region;
+        let quadrant = spacelineLocation.quadrant;
         let blueprintId = cardJson.blueprintId;
         let zone = "SPACELINE";
         let cardId = cardJson.cardId;

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1141,7 +1141,7 @@ export default class GameTableUI {
                     let missionCard = gameState.visibleCardsInGame[missionCardId];
                     let spacelineIndex = getSpacelineIndexFromLocationId(missionCard.locationId, gameState);
                     let firstMissionAtLocation = (i == 0);
-                    this.animations.putMissionIntoPlay(missionCard, false, spacelineIndex, firstMissionAtLocation);
+                    this.animations.putMissionIntoPlay(missionCard, false, location, spacelineIndex, firstMissionAtLocation);
                     cardsAdded.push(missionCardId);
                     cardsStillToAdd = removeFromArray(cardsStillToAdd, missionCardId);
                 }

--- a/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/Region.java
+++ b/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/Region.java
@@ -13,6 +13,7 @@ public enum Region implements Filterable {
 
     @JsonValue
     public String getJsonValue() {
+        // TODO: Please send the client the enum name
         return switch(this) {
             case QO_NOS_SYSTEM -> "Qo'Nos System";
             default -> name().replace("_", " ");

--- a/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/Region.java
+++ b/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/Region.java
@@ -1,7 +1,5 @@
 package com.gempukku.stccg.common.filterable;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 @SuppressWarnings({"SpellCheckingInspection", "unused"})
 public enum Region implements Filterable {
     ARGOLIS_CLUSTER, BADLANDS, BAJOR, BRIAR_PATCH, CARDASSIA, CETI_ALPHA, CHIN_TOKA,
@@ -9,14 +7,6 @@ public enum Region implements Filterable {
     NORTHWEST_PASSAGE, ROMULUS_SYSTEM, SECTOR_001, TELLUN, VALO,
 
     //2E regions
-    QO_NOS_SYSTEM;
+    QO_NOS_SYSTEM
 
-    @JsonValue
-    public String getJsonValue() {
-        // TODO: Please send the client the enum name
-        return switch(this) {
-            case QO_NOS_SYSTEM -> "Qo'Nos System";
-            default -> name().replace("_", " ");
-        };
-    }
 }


### PR DESCRIPTION
### Summary
Fixes quadrant background colors and tooltips.

### TODO
@datanoh Region.java should send the raw enum value so I can rely on it in the client. If you know of any other client cases where it's used, I can fix those to use the updated friendly name code. Thanks!