### PR TITLE
Fixed bug in deck builder

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -330,7 +330,7 @@ export default class GempLotrDeckBuildingUI {
     loadDeckList() {
         var that = this;
         this.comm.listUserDecks(function (json) {
-            if (that.deckListDialog === null) {
+            if (that.deckListDialog === null || typeof that.deckListDialog === "undefined") {
                 that.deckListDialog = $("<div></div>")
                         .dialog({
                     title:"Your Saved Decks",
@@ -426,7 +426,7 @@ export default class GempLotrDeckBuildingUI {
     loadLibraryList() {
         var that = this;
         this.comm.listLibraryDecks(function (json) {
-            if (that.deckListDialog === null) {
+            if (that.deckListDialog === null || typeof that.deckListDialog === "undefined") {
                 that.deckListDialog = $("<div></div>")
                         .dialog({
                     title:"Library Decks",


### PR DESCRIPTION
Fixed a bug in the deck builder where deckListDialog wasn't being populated, because it was undefined instead of null. I believe this bug was introduced by replacing == with ===, and I suspect similar changes in if conditions will have created bugs I haven't observed yet.