### PR TITLE
Add a seeded card badge to missions.

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -230,6 +230,20 @@ red/pink: #C2599F
 	color: white;
 }
 
+.seedCardCountBadge::after {
+	content: attr(seedCardCount);
+    position: relative;
+    top: -42%;
+    left: 39%;
+    border-radius: 50%;
+    padding: 5%;
+	background: #c25959;
+    opacity: 0.9;
+    font-size: 12px;
+    font-weight: bolder;
+	color: white;
+}
+
 .stats {
     text-align: center;
     padding: 2px;

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -1,4 +1,5 @@
 import { showLinkableCardTitle, getAffiliationHtml } from "./common.js";
+import { getCardDivFromId } from "./jCards.js";
 
 export function animateActionResult(jsonAction, jsonGameState, gameAnimations) {
     let actionType = jsonAction.actionType;
@@ -6,6 +7,19 @@ export function animateActionResult(jsonAction, jsonGameState, gameAnimations) {
     let cardList = new Array();
     let targetCard;
     let spacelineIndex;
+
+    for (const location of jsonGameState.spacelineLocations) {
+        if (location.seedCardCount === 0) {
+            for (const missionId of location.missionCardIds) {
+                getCardDivFromId(missionId).removeClass("seedCardCountBadge").removeAttr("seedCardCount");
+            }
+        }
+        else {
+            for (const missionId of location.missionCardIds) {
+                getCardDivFromId(missionId).addClass("seedCardCountBadge").attr("seedCardCount", location.seedCardCount);
+            }
+        }
+    }
 
     switch(actionType) {
         case "ADD_CARD_TO_PRESEED_STACK": // preparing for dilemma seeds; only animation is to remove from "hand"


### PR DESCRIPTION
### Summary of Changes
Every time an event is fired, we now check missions for the number of cards they have seeded and update the number. A red badge is placed on top of the card. There is no other tooltip indicating what the badge is for.

![image](https://github.com/user-attachments/assets/acfd24c2-28eb-4b70-be7c-599314f0bdd4)


### Benefits
Better UI than Lackey or IRL.

### Risks
Not rigorously tested.
Not automated tested.

### Possible Improvements to this PR
Perhaps we could tooltip onHover to tell the user what the badge is for, or put an icon next to it.

If we know what events might cause a mission's number of seeded cards to change, we could reduce the number of times this fires by:

1. Move this for loop into a function
2. Calling it only on the events that might change it