### PR TITLE
Card modifiers for demo

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -748,7 +748,7 @@ export default class GameTableUI {
         }
 
         // Indicate if card is stopped
-        if (isStopped != null) {
+        if (isStopped) {
             html = html + "<i>Stopped</i><br/>";
         }
 

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -718,6 +718,7 @@ export default class GameTableUI {
     setCardModifiers(json) {
         // DEBUG: console.log("Calling setCardModifiers");
         let modifiers = json.modifiers; // list of HTML strings
+        let isStopped = json.isStopped; // boolean
         let affiliations = json.affiliations; // list of HTML strings
         let icons = json.icons; // list of HTML strings
         let crew = json.crew; // list of other cards with specific properties
@@ -739,9 +740,16 @@ export default class GameTableUI {
         if (modifiers != null && modifiers.length > 0) {
             html = html + "<b>Active Modifiers:</b><br/>";
             for (const modifier of modifiers) {
-                html = html + modifier + "<br/>";
+                if (modifier != "null") {
+                    html = html + modifier + "<br/>";
+                }
             }
             html = html + "<br/>";
+        }
+
+        // Indicate if card is stopped
+        if (isStopped != null) {
+            html = html + "<i>Stopped</i><br/>";
         }
 
         // Show icons for affiliation(s)

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/game/CardGameMediator.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/game/CardGameMediator.java
@@ -410,9 +410,15 @@ public abstract class CardGameMediator {
 
         Collection<String> modifiersToAdd = new ArrayList<>();
         for (Modifier modifier : cardGame.getGameState().getModifiersQuerying().getModifiersAffecting(card)) {
-            modifiersToAdd.add(modifier.getCardInfoText(getGame(), card));
+            if (modifier != null && !Objects.equals(modifier.getCardInfoText(getGame(), card), "null")) {
+                modifiersToAdd.add(modifier.getCardInfoText(getGame(), card));
+            }
         }
         itemsToSerialize.put("modifiers", modifiersToAdd);
+
+        if (card instanceof ST1EPhysicalCard stCard) {
+            itemsToSerialize.put("isStopped", stCard.isStopped());
+        }
 
         List<String> affiliationTexts = new ArrayList<>();
         if (card instanceof AffiliatedCard affiliatedCard) {
@@ -505,6 +511,7 @@ public abstract class CardGameMediator {
         boolean hasUniversalIcon = card.isUniversal() &&
                 cardTypesShowingUniversal.contains(card.getCardType());
         cardMap.put("hasUniversalIcon", hasUniversalIcon);
+
         return cardMap;
     }
 }


### PR DESCRIPTION
Added a "stopped" indicator to the setCardModifiers dialog. Not intended to be a permanent solution, but I wanted a way to confirm within the UI that a personnel or ship was stopped after it had happened.

![image](https://github.com/user-attachments/assets/8274db08-50af-4250-a554-2047068622ce)

Also added some null handling on both the client and server side for the same dialog.