### PR TITLE
Refreshing play history messages when client is reloaded

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1166,6 +1166,11 @@ export default class GameTableUI {
             }
 
             this.setupClocks(jsonNode.gameState);
+
+            for (const action of gameState.performedActions) {
+                communicateActionResult(action, gameState, this);
+            }
+
             this.lastActionIndex = jsonNode.gameState.performedActions.length - 1;
 
             let pendingDecision = gameState.pendingDecision;


### PR DESCRIPTION
If the client reloads (for example, by hitting refresh in the browser), the play history messages will be repopulated from the gamestate performedActions list. No animations will be performed.

Helpful for both end users and testing to identify what's going on in the game after a client error.