### PR TITLE
Reveal card data

### DIFF
--- a/gemp-module/gemp-stccg-client/package-lock.json
+++ b/gemp-module/gemp-stccg-client/package-lock.json
@@ -10,7 +10,9 @@
         "@fontsource/roboto": "^5.1.1",
         "@mui/lab": "^6.0.0-beta.22",
         "@mui/material": "^6.3.1",
+        "delay": "^6.0.0",
         "js-cookie": "^3.0.5",
+        "p-queue": "^8.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -4842,6 +4844,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delay": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-6.0.0.tgz",
+      "integrity": "sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5256,6 +5270,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -7116,6 +7136,34 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/gemp-module/gemp-stccg-client/package.json
+++ b/gemp-module/gemp-stccg-client/package.json
@@ -29,7 +29,9 @@
     "@fontsource/roboto": "^5.1.1",
     "@mui/lab": "^6.0.0-beta.22",
     "@mui/material": "^6.3.1",
+    "delay": "^6.0.0",
     "js-cookie": "^3.0.5",
+    "p-queue": "^8.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/gemp-module/gemp-stccg-client/src/main/web/__mocks__/delay.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/__mocks__/delay.js
@@ -1,0 +1,4 @@
+export default class Delay {
+    constructor() {
+      return this;
+    }}

--- a/gemp-module/gemp-stccg-client/src/main/web/__mocks__/p-queue.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/__mocks__/p-queue.js
@@ -1,0 +1,10 @@
+export default class PQueue {
+    constructor() {
+      return this;
+    }
+    add(fn) {
+      return fn();
+    }
+    pause() {}
+    clear() {}
+}

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -536,7 +536,7 @@ red/pink: #C2599F
     height: 1em;
 }
 
-#animationLayer {
+#animation-layer {
     position: absolute; /* render on top of main */
     height: 100%;
     width: 100%;

--- a/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
+++ b/gemp-module/gemp-stccg-client/src/main/web/css/gemp-001/game.css
@@ -535,3 +535,17 @@ red/pink: #C2599F
 .inline-icon {
     height: 1em;
 }
+
+#animationLayer {
+    position: absolute; /* render on top of main */
+    height: 100%;
+    width: 100%;
+    z-index: 200; /* TODO: Put these z-index levels in common or something. */
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center; /* horiz */
+    align-content: center; /* vert */
+    gap: 15px;
+    background-color: #5b5b5b90; /* semitransparent gray */
+    opacity: 0; /* start invisible */
+}

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -256,7 +256,16 @@ export function communicateActionResult(jsonAction, jsonGameState, gameUi) {
         case "ADD_MODIFIER": // No notifications sent when adding modifiers
         case "DOCK_SHIP":
         case "DOWNLOAD_CARD": // currently this is just a wrapper for PLAY_CARD
-        case "ENCOUNTER_SEED_CARD":
+        case "ENCOUNTER_SEED_CARD": {
+            targetCard = getActionTargetCard(jsonAction, jsonGameState);
+            if (jsonAction.status === "completed_success") {
+                message = performingPlayerId + " overcame " + showLinkableCardTitle(targetCard);
+            } else if (jsonAction.status === "completed_failure") {
+                message = performingPlayerId + " failed to overcome " + showLinkableCardTitle(targetCard);
+            }
+            gameChat.appendMessage(message, "gameMessage");
+            break;
+        }
         case "FAIL_DILEMMA":
         case "OVERCOME_DILEMMA":
         case "PLACE_CARD_ON_MISSION":

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -3,7 +3,7 @@ import { getCardDivFromId } from "./jCards.js";
 
 export function animateActionResult(jsonAction, jsonGameState, gameAnimations) {
     let actionType = jsonAction.actionType;
-    console.log("Calling animateActionResult for " + actionType);
+    // console.log("Calling animateActionResult for " + actionType);
     let cardList = new Array();
     let targetCard;
     let spacelineIndex;
@@ -156,7 +156,7 @@ export function communicateActionResult(jsonAction, jsonGameState, gameUi) {
     let actionType = jsonAction.actionType;
     let performingPlayerId = jsonAction.performingPlayerId;
     let message;
-    console.log("Calling communicateActionResult for " + actionType);
+    // console.log("Calling communicateActionResult for " + actionType);
     let gameChat = gameUi.chatBox;
     let targetCard;
 
@@ -180,9 +180,9 @@ export function communicateActionResult(jsonAction, jsonGameState, gameUi) {
             break;
         case "CHANGE_AFFILIATION": {
             let targetCardId = jsonAction.targetCardId;
-            console.log("targetCardId: " + targetCardId);
+            // console.log("targetCardId: " + targetCardId);
             let card = jsonGameState.visibleCardsInGame[targetCardId];
-            console.log("card: " + card.title);
+            // console.log("card: " + card.title);
                 // getCardLink and change selectedAffiliation to HTML
             message = performingPlayerId + " changed " + showLinkableCardTitle(card) + "'s affiliation to " +
                 getAffiliationHtml(card.affiliation);
@@ -324,6 +324,6 @@ export function getSpacelineIndexFromLocationId(locationId, gameState) {
             return i;
         }
     }
-    console.log("Spaceline index for locationId " + locationId + " not found");
+    console.log("Spaceline index for locationId " + locationId + " not found"); // normal for core cards
     return -1;
 }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -256,6 +256,7 @@ export function communicateActionResult(jsonAction, jsonGameState, gameUi) {
         case "ADD_MODIFIER": // No notifications sent when adding modifiers
         case "DOCK_SHIP":
         case "DOWNLOAD_CARD": // currently this is just a wrapper for PLAY_CARD
+            break;
         case "ENCOUNTER_SEED_CARD": {
             targetCard = getActionTargetCard(jsonAction, jsonGameState);
             if (jsonAction.status === "completed_success") {

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/actionResults.js
@@ -115,10 +115,12 @@ export function animateActionResult(jsonAction, jsonGameState, gameAnimations) {
         case "ENCOUNTER_SEED_CARD": // no animation
         case "OVERCOME_DILEMMA": // no animation
         case "PLACE_CARD_ON_MISSION": // no animation included yet
-        case "REVEAL_SEED_CARD": // no animation included yet
             break;
-        case "STOP_CARDS": // no animation included yet
-            gameAnimations.stopCards(jsonAction.targetCardIds, jsonGameState);
+        case "REVEAL_SEED_CARD":
+            gameAnimations.revealCard(jsonAction.targetCardId, jsonGameState).then(() => {return});
+            break;
+        case "STOP_CARDS":
+            gameAnimations.stopCards(jsonAction.targetCardIds, jsonGameState).then(() => {return});
             break;
         // Actions that are just wrappers for decisions
         case "MAKE_DECISION":

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -587,6 +587,117 @@ export default class GameAnimations {
                 });
     }
 
+    revealCard(targetCardId, jsonGameState) {
+        // TODO: Create a permanent animation layer that's invisible so I don't have to copy this every time.
+        let animation_layer = document.createElement("div");
+        animation_layer.id = "animation_layer";
+        animation_layer.style.position = "absolute"; // render on top
+        animation_layer.style.height = "100%";
+        animation_layer.style.width = "100%";
+        animation_layer.style.zIndex = 200; // TODO: Put these z-index levels in common or something.
+        animation_layer.style.display = "flex";
+        animation_layer.style.flexWrap = "wrap";
+        animation_layer.style.justifyContent = "center"; //horiz
+        animation_layer.style.alignContent = "center"; //vert
+        animation_layer.style.gap = "15px";
+        animation_layer.style.backgroundColor = "#5b5b5b90"; // semitransparent gray
+        animation_layer.style.opacity = 0; // invisible
+
+        let card_json = jsonGameState.visibleCardsInGame[targetCardId];
+        let blueprintId = card_json.blueprintId;
+        let zone = "VOID";
+        let cardId = card_json.cardId;
+        let noOwner = "";
+        let imageUrl = card_json.imageUrl;
+        let emptyLocationIndex = "";
+        let upsideDown = false;
+        let card = new Card(blueprintId, zone, cardId, noOwner, imageUrl, emptyLocationIndex, upsideDown);
+        let text = "";
+
+        let baseCardDiv = createCardDiv(card.imageUrl, text, card.isFoil(), card.status_tokens, false, card.hasErrata(), card.isUpsideDown(), card.cardId);
+
+        let pageWidth = document.body.clientWidth;
+        let oneSixthWidthVal = (pageWidth / 6);
+        let cardWidth = oneSixthWidthVal + "px"; // 5 width
+        let cardHeight = Math.floor(oneSixthWidthVal * 1.5) + "px"; // 3:2 ratio
+
+        baseCardDiv.style.margin = "auto";
+        baseCardDiv.style.width = cardWidth;
+        baseCardDiv.style.height = cardHeight;
+        baseCardDiv.style.flex = `0 1 ${cardWidth}`;
+        
+        let threeDCardLayer = baseCardDiv.getElementsByClassName("three-d-card")[0];
+        threeDCardLayer.classList.add("facedown"); // TODO make this part of the createCardDiv options
+
+        animation_layer.appendChild(baseCardDiv);
+
+        new Promise((resolve, _reject) => {
+            let gamediv;
+            if (this.game.mainDiv instanceof jQuery) {
+                gamediv = this.game.mainDiv[0];
+            }
+            else {
+                gamediv = this.game;
+            }
+            gamediv.appendChild(animation_layer);
+            resolve();
+        })
+        .then(() => {
+            // fade in
+            return this.animateElementAndSaveCSSPromise(
+                animation_layer,
+                [
+                    { // from
+                        opacity: 0,
+                    },
+                    { // to
+                        opacity: 1,
+                    },
+                ],
+                {
+                    duration: 500, //ms
+                    fill: "forwards"
+                }
+            );
+        })
+        .then(() => {
+            // flip the card over
+            return new Promise((resolve, _reject) => {
+                let cardsToFlip = animation_layer.getElementsByClassName("facedown");
+                for (card of cardsToFlip) {
+                    card.classList.remove("facedown");
+                }
+                // wait 2s for people to read them
+                setTimeout(resolve, 2000); // important to NOT put resolve parens here
+            })
+        })
+        .then(() => {
+            // fade out
+            return this.animateElementAndSaveCSSPromise(
+                animation_layer,
+                [
+                    { // from
+                        opacity: 1,
+                    },
+                    { // to
+                        opacity: 0,
+                    },
+                ],
+                {
+                    duration: 500, //ms
+                    fill: "forwards"
+                }
+            );
+        })
+        .then(() => {
+            // remove animation layer
+            return new Promise((resolve, _reject) => {
+                animation_layer.remove();
+                resolve();
+            });
+        });
+    }
+
     stopCards(targetCardIds, jsonGameState) {     
         let animation_layer = document.createElement("div");
         animation_layer.id = "animation_layer";

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -235,7 +235,7 @@ export default class GameAnimations {
 
     addCardToHiddenZone(cardJson, zone, zoneOwner) {
         // Adding card to discard, hand, removed, or draw deck
-        console.log("calling addCardToHiddenZone");
+        // console.log("calling addCardToHiddenZone");
         var that = this;
         let cardId = cardJson.cardId;
         let imageUrl = cardJson.imageUrl;
@@ -271,9 +271,9 @@ export default class GameAnimations {
     putMissionIntoPlay(cardJson, animate, spacelineLocation, spacelineIndex, firstMissionAtLocation) {
         // int spacelineIndex: index of mission's location in game state spaceline array
         // boolean firstMissionAtLocation: true if bottom or only mission card; false if card is in top of another mission card
-        console.log("Calling putMissionIntoPlay");
-        console.log(cardJson);
-        console.log(spacelineIndex);
+        // console.log("Calling putMissionIntoPlay");
+        // console.log(cardJson);
+        // console.log(spacelineIndex);
         var that = this;
         let region = spacelineLocation.region;
         let quadrant = spacelineLocation.quadrant;
@@ -290,10 +290,10 @@ export default class GameAnimations {
             function (next) {
 
                 if (firstMissionAtLocation) {
-                    console.log("Adding mission " + cardJson.title + " at location index " + spacelineIndex);
+                    // console.log("Adding mission " + cardJson.title + " at location index " + spacelineIndex);
                     thisGame.addLocationDiv(locationIndex, quadrant, region);
                 } else {
-                    console.log("Adding mission card " + cardJson.title + " to location index " + spacelineIndex);
+                    // console.log("Adding mission card " + cardJson.title + " to location index " + spacelineIndex);
                     thisGame.addSharedMission(locationIndex, quadrant, region);
                 }
 
@@ -593,23 +593,10 @@ export default class GameAnimations {
 
     async revealCard(targetCardId, jsonGameState) {
         await this.queue.add(async () => {
-            console.log(`revealCard processing started at ${new Date().toLocaleString()}`);
-
             // animation layer setup
             // TODO: Create a permanent animation layer that's invisible so I don't have to copy this every time.
             let animation_layer = document.createElement("div");
-            animation_layer.id = "animation_layer";
-            animation_layer.style.position = "absolute"; // render on top
-            animation_layer.style.height = "100%";
-            animation_layer.style.width = "100%";
-            animation_layer.style.zIndex = 200; // TODO: Put these z-index levels in common or something.
-            animation_layer.style.display = "flex";
-            animation_layer.style.flexWrap = "wrap";
-            animation_layer.style.justifyContent = "center"; //horiz
-            animation_layer.style.alignContent = "center"; //vert
-            animation_layer.style.gap = "15px";
-            animation_layer.style.backgroundColor = "#5b5b5b90"; // semitransparent gray
-            animation_layer.style.opacity = 0; // invisible
+            animation_layer.id = "animation-layer";
 
             let card_json = jsonGameState.visibleCardsInGame[targetCardId];
             let blueprintId = card_json.blueprintId;
@@ -691,27 +678,14 @@ export default class GameAnimations {
             );
 
             animation_layer.remove();
-            console.log(`revealCard done at ${new Date().toLocaleString()}`);
         });
     }
 
     async stopCards(targetCardIds, jsonGameState) {
         await this.queue.add(async () => {
-            console.log(`stopCards processing started at ${new Date().toLocaleString()}`);
             // animation layer setup
             let animation_layer = document.createElement("div");
-            animation_layer.id = "animation_layer";
-            animation_layer.style.position = "absolute"; // render on top
-            animation_layer.style.height = "100%";
-            animation_layer.style.width = "100%";
-            animation_layer.style.zIndex = 200; // TODO: Put these z-index levels in common or something.
-            animation_layer.style.display = "flex";
-            animation_layer.style.flexWrap = "wrap";
-            animation_layer.style.justifyContent = "center"; //horiz
-            animation_layer.style.alignContent = "center"; //vert
-            animation_layer.style.gap = "15px";
-            animation_layer.style.backgroundColor = "#5b5b5b90"; // semitransparent gray
-            animation_layer.style.opacity = 0; // invisible
+            animation_layer.id = "animation-layer";
 
             for (const targetCardId of targetCardIds) {
                 let card_json = jsonGameState.visibleCardsInGame[targetCardId];
@@ -805,7 +779,6 @@ export default class GameAnimations {
             );
             
             animation_layer.remove();
-            console.log(`stopCards done at ${new Date().toLocaleString()}`);
         });
     }
 
@@ -828,16 +801,16 @@ export default class GameAnimations {
     removeCardFromPlay(cardRemovedIds, performingPlayerId, animate) {
         // This method may be called on cards that are not "in play" but visible on the board (like those in hands)
         var that = this;
-        console.log("Calling removeCardFromPlay");
-        console.log(cardRemovedIds);
-        console.log(performingPlayerId);
-        console.log(animate);
+        // console.log("Calling removeCardFromPlay");
+        // console.log(cardRemovedIds);
+        // console.log(performingPlayerId);
+        // console.log(animate);
 
         if (animate && (this.game.spectatorMode || this.game.replayMode || (performingPlayerId != this.game.bottomPlayerId))) {
             $("#main").queue(
                 function (next) {
                     for (const cardId of cardRemovedIds) {
-                        console.log("Removing card with cardId '" + cardId + "'");
+                        // console.log("Removing card with cardId '" + cardId + "'");
                         let cardDiv = getCardDivFromId(cardId);
                         if (cardDiv.length > 0) {
                             cardDiv.animate(

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -587,16 +587,7 @@ export default class GameAnimations {
                 });
     }
 
-    stopCards(targetCardIds, jsonGameState) {
-        /*
-        for (const cardId of targetCardIds) {
-            //getCardDivFromId()
-            //apply css
-            let cardToAnimate = jsonGameState.visibleCardsInGame[cardId];
-            console.log(`Stop animation for ${cardToAnimate.title}`);
-        }
-        */
-        
+    stopCards(targetCardIds, jsonGameState) {     
         let animation_layer = document.createElement("div");
         animation_layer.id = "animation_layer";
         animation_layer.style.position = "absolute"; // render on top
@@ -609,24 +600,9 @@ export default class GameAnimations {
         animation_layer.style.alignContent = "center"; //vert
         animation_layer.style.gap = "15px";
         animation_layer.style.backgroundColor = "#5b5b5b90"; // semitransparent gray
-        //animation_layer.style.minHeight = "200px";
         animation_layer.style.opacity = 0; // invisible
 
-        // create a cardDiv for each card
-        // opacity fade entire group in
-        // drop the stop icon onto each of them
-        // opacity fade entire group out
-        // remove animation_layer
-
-        // create a card div for each card
         for (const targetCardId of targetCardIds) {
-            //apply css
-            //console.log(`Stop animation for ${cardToAnimate.title}`);
-
-            //let card_grid_item = document.createElement("div");
-            //card_grid_item.innerHTML = `${cardId}`;
-            //card_grid_item.style.padding = "5px";
-            //card_grid_item.style.backgroundColor = "#ffffff";
             let card_json = jsonGameState.visibleCardsInGame[targetCardId];
             let blueprintId = card_json.blueprintId;
             let zone = "VOID";
@@ -690,7 +666,7 @@ export default class GameAnimations {
             );
         })
         .then(() => {
-            // delay
+            // animate all token overlays on every card
             return new Promise((resolve, _reject) => {
                 const tokenOverlays = animation_layer.getElementsByClassName("tokenOverlay");
                 let animation_promises = [];

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1089,7 +1089,7 @@ export default class GameTableUI {
             let cardToAdd;
 
             if (gameState.players != null && gameState.players.length > 0) {
-                console.log("Calling initializePlayerOrder from initializeGameState");
+                // console.log("Calling initializePlayerOrder from initializeGameState");
                 this.initializePlayerOrder(gameState);
                 this.updateGameStats(gameState);
             }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameUi.js
@@ -1050,7 +1050,8 @@ export default class GameTableUI {
                     if (action.status === "completed_success") {
                         animateActionResult(action, gameState, this.animations);
                         communicateActionResult(action, gameState, this);
-                    } else if (action.status === "completed_failure" && action.actionType === "ATTEMPT_MISSION") {
+                    } else if (action.status === "completed_failure" && (action.actionType === "ATTEMPT_MISSION" || action.actionType === "ENCOUNTER_SEED_CARD")) {
+                        // Pass a message to the play history if a mission attempt or seed card encounter was failed
                         communicateActionResult(action, gameState, this);
                     }
                     this.lastActionIndex = i;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/EncounterSeedCardAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/EncounterSeedCardAction.java
@@ -1,5 +1,7 @@
 package com.gempukku.stccg.actions.missionattempt;
 
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gempukku.stccg.actions.*;
 import com.gempukku.stccg.actions.discard.RemoveDilemmaFromGameAction;
 import com.gempukku.stccg.cards.AttemptingUnit;
@@ -24,7 +26,7 @@ public class EncounterSeedCardAction extends ActionyAction implements TopLevelSe
                                    AttemptingUnit attemptingUnit, AttemptMissionAction attemptAction,
                                    MissionLocation location)
             throws InvalidGameLogicException {
-        super(cardGame, encounteringPlayer, "Reveal seed card", ActionType.ENCOUNTER_SEED_CARD, Progress.values());
+        super(cardGame, encounteringPlayer, "Encounter seed card", ActionType.ENCOUNTER_SEED_CARD, Progress.values());
         try {
             _parentAction = Objects.requireNonNull(attemptAction);
             _cardTarget = new FixedCardResolver(encounteredCard);
@@ -63,6 +65,8 @@ public class EncounterSeedCardAction extends ActionyAction implements TopLevelSe
     public PhysicalCard getEncounteredCard() { return _cardTarget.getCard(); }
     public AttemptMissionAction getAttemptAction() { return _parentAction; }
 
+    @JsonProperty("targetCardId")
+    @JsonIdentityReference(alwaysAsId=true)
     @Override
     public PhysicalCard getPerformingCard() {
         return _cardTarget.getCard();

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/RevealSeedCardAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/missionattempt/RevealSeedCardAction.java
@@ -30,6 +30,7 @@ public class RevealSeedCardAction extends ActionyAction {
         _revealedCardId = revealedCard.getCardId();
         _missionAttemptActionId = attemptAction.getActionId();
         _missionLocation = mission;
+        revealedCard.reveal();
     }
 
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AbstractPhysicalCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/AbstractPhysicalCard.java
@@ -43,6 +43,7 @@ public abstract class AbstractPhysicalCard implements PhysicalCard {
     protected MissionLocation _currentLocation;
     protected GameLocation _currentGameLocation;
     private boolean _placedOnMission = false;
+    private boolean _revealedSeedCard = false;
 
     public AbstractPhysicalCard(int cardId, Player owner, CardBlueprint blueprint) {
         _cardId = cardId;
@@ -406,7 +407,7 @@ public abstract class AbstractPhysicalCard implements PhysicalCard {
 
     public boolean isKnownToPlayer(String playerName) {
         return _zone.isPublic() || _owner.getPlayerId().equals(playerName) ||
-                isControlledBy(playerName);
+                isControlledBy(playerName) || _revealedSeedCard;
     }
 
     public boolean isVisibleToPlayer(String playerName) {
@@ -421,6 +422,10 @@ public abstract class AbstractPhysicalCard implements PhysicalCard {
         PhysicalCardGroup group = _owner.getCardGroup(_zone);
         if (group != null)
             group.remove(this);
+    }
+
+    public void reveal() {
+        _revealedSeedCard = true;
     }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCard.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/physicalcard/PhysicalCard.java
@@ -170,4 +170,6 @@ public interface PhysicalCard extends Filterable {
     default Integer getStrength(DefaultGame cardGame) {
         return cardGame.getGameState().getModifiersQuerying().getStrength(this);
     }
+
+    void reveal();
 }


### PR DESCRIPTION
Added a little more information to the client for context with dilemma encounters. The game state should now be populated with full data for a card being encountered, and both REVEAL_SEED_CARD_ACTION and ENCOUNTER_SEED_CARD_ACTION have the targetCardId property.

@andrewd18 - If you have any ideas for this that could be quickly implemented, go for it. At the moment it's a little hard to identify the order in which mission attempt subactions are happening within the UI. It's not incorrect by any means, just might take a little explaining in the demo.

Thoughts off the top of my head:
- Pop up the card image when it's revealed for a few seconds, similar to how stop cards is doing it
- Pop up the card image when the encounter is completed for a few seconds, with a success/failure indicator of some kind?

I realize these are very 11th hour asks for the demo, so no worries if it's just not reasonable to add anything else for this.