### PR TITLE
Continuing mission fix

### DIFF
--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set155.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set155.hjson
@@ -65,6 +65,7 @@
                         type: played
                         filter: self
                     }
+                    triggerDuringSeed: true
                     effect: {
                         type: download
                         target: {
@@ -76,6 +77,7 @@
                 }
                 {
                     type: requiredTrigger
+                    triggerDuringSeed: true
                     trigger: {
                         type: played
                         player: you
@@ -93,6 +95,7 @@
                         player: you
                         filter: personnel + tng-icon + skill-dots<=4 + sd-icons=0
                     }
+                    triggerDuringSeed: false
                     effect: {
                         type: drawCards
                     }

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set167.hjson
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set167.hjson
@@ -20,6 +20,7 @@
                         type: played
                         filter: self
                     }
+                    triggerDuringSeed: true
                     effect: {
                         type: download
                         target: {
@@ -31,6 +32,7 @@
                 }
                 {
                     type: requiredTrigger
+                    triggerDuringSeed: true
                     trigger: {
                         type: played
                         player: you

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/ActivateCardActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/ActivateCardActionBlueprint.java
@@ -17,8 +17,6 @@ public class ActivateCardActionBlueprint extends DefaultActionBlueprint {
                                     String text,
                                        @JsonProperty(value="limitPerTurn", defaultValue="0")
                                     int limitPerTurn,
-                                       @JsonProperty("phase")
-                                    Phase phase,
                                        @JsonProperty("requires")
                                        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                     List<Requirement> requirements,
@@ -28,11 +26,10 @@ public class ActivateCardActionBlueprint extends DefaultActionBlueprint {
                                        @JsonProperty("effect")
                                        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                     List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
-            super(text, limitPerTurn, phase);
+            super(text, limitPerTurn, costs, effects);
             if (requirements != null && !requirements.isEmpty()) {
                 _requirements.addAll(requirements);
             }
-            addCostsAndEffects(costs, effects);
     }
 
     public ActivateCardAction createAction(PhysicalCard card) { return new ActivateCardAction(card.getGame(), card); }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/ActivateCardActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/ActivateCardActionBlueprint.java
@@ -29,7 +29,10 @@ public class ActivateCardActionBlueprint extends DefaultActionBlueprint {
                                        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                     List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
             super(text, limitPerTurn, phase);
-            processRequirementsCostsAndEffects(requirements, costs, effects);
+            if (requirements != null && !requirements.isEmpty()) {
+                _requirements.addAll(requirements);
+            }
+            addCostsAndEffects(costs, effects);
     }
 
     public ActivateCardAction createAction(PhysicalCard card) { return new ActivateCardAction(card.getGame(), card); }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DefaultActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DefaultActionBlueprint.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public abstract class DefaultActionBlueprint implements ActionBlueprint {
-    private final List<Requirement> requirements = new LinkedList<>();
+    protected final List<Requirement> _requirements = new LinkedList<>();
 
     protected final List<SubActionBlueprint> costs = new LinkedList<>();
     protected final List<SubActionBlueprint> effects = new LinkedList<>();
@@ -38,7 +38,7 @@ public abstract class DefaultActionBlueprint implements ActionBlueprint {
     }
 
     public void addRequirement(Requirement requirement) {
-        this.requirements.add(requirement);
+        this._requirements.add(requirement);
     }
 
     public void addCost(SubActionBlueprint subActionBlueprint) {
@@ -51,7 +51,7 @@ public abstract class DefaultActionBlueprint implements ActionBlueprint {
 
     @Override
     public boolean isValid(ActionContext actionContext) {
-        return actionContext.acceptsAllRequirements(requirements);
+        return actionContext.acceptsAllRequirements(_requirements);
     }
 
     @Override
@@ -64,18 +64,11 @@ public abstract class DefaultActionBlueprint implements ActionBlueprint {
         effects.forEach(actionEffect -> actionEffect.addEffectToAction(false, action, actionContext));
     }
 
-    public void processRequirementsCostsAndEffects(List<Requirement> requirements, List<SubActionBlueprint> costs,
-                                                   List<SubActionBlueprint> effects)
+    public void addCostsAndEffects(List<SubActionBlueprint> costs, List<SubActionBlueprint> effects)
             throws InvalidCardDefinitionException {
 
         if ((costs == null || costs.isEmpty()) && (effects == null || effects.isEmpty()))
             throw new InvalidCardDefinitionException("Action does not contain a cost, nor effect");
-
-        if (requirements != null && !requirements.isEmpty()) {
-            for (Requirement requirement : requirements) {
-                addRequirement(requirement);
-            }
-        }
 
         if (costs != null && !costs.isEmpty()) {
             for (SubActionBlueprint costBlueprint : costs) {
@@ -92,11 +85,6 @@ public abstract class DefaultActionBlueprint implements ActionBlueprint {
             }
         }
     }
-
-
-
-
-
 
     protected abstract TopLevelSelectableAction createActionAndAppendToContext(PhysicalCard card, ActionContext context);
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DefaultActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DefaultActionBlueprint.java
@@ -23,6 +23,13 @@ public abstract class DefaultActionBlueprint implements ActionBlueprint {
 
     protected String _text;
 
+    public DefaultActionBlueprint(String text, int limitPerTurn) {
+        if (text != null)
+            setText(text);
+        if (limitPerTurn > 0)
+            setTurnLimit(limitPerTurn);
+    }
+
     public DefaultActionBlueprint(String text, int limitPerTurn, Phase phase) {
             if (text != null)
                 setText(text);

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/EncounterSeedCardActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/EncounterSeedCardActionBlueprint.java
@@ -27,7 +27,7 @@ public class EncounterSeedCardActionBlueprint extends DefaultActionBlueprint {
     public EncounterSeedCardActionBlueprint(@JsonProperty("effect")
                                             @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                             List<SubActionBlueprint> effects) {
-        super("Encounter card", 0, Phase.EXECUTE_ORDERS);
+        super("Encounter card", 0);
         _effects = Objects.requireNonNullElse(effects, new LinkedList<>());
     }
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/OptionalTriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/OptionalTriggerActionBlueprint.java
@@ -20,6 +20,8 @@ public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
                                        String text,
                                           @JsonProperty(value="limitPerTurn", defaultValue="0")
                                        int limitPerTurn,
+                                          @JsonProperty(value="triggerDuringSeed", required = true)
+                                      boolean triggerDuringSeed,
                                           @JsonProperty("phase")
                                        Phase phase,
                                           @JsonProperty("trigger")
@@ -32,7 +34,8 @@ public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
                                           @JsonProperty("effect")
                                           @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                           List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
-        super(RequiredType.OPTIONAL, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects);
+        super(RequiredType.OPTIONAL, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects,
+                triggerDuringSeed);
     }
 
     @Override

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/OptionalTriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/OptionalTriggerActionBlueprint.java
@@ -8,13 +8,10 @@ import com.gempukku.stccg.cards.InvalidCardDefinitionException;
 import com.gempukku.stccg.requirement.Requirement;
 import com.gempukku.stccg.requirement.trigger.TriggerChecker;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
-import com.gempukku.stccg.common.filterable.Phase;
-import com.gempukku.stccg.common.filterable.RequiredType;
 
 import java.util.List;
 
 public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
-    private final RequiredType _requiredType = RequiredType.OPTIONAL;
 
     public OptionalTriggerActionBlueprint(@JsonProperty("text")
                                        String text,
@@ -22,8 +19,6 @@ public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
                                        int limitPerTurn,
                                           @JsonProperty(value="triggerDuringSeed", required = true)
                                       boolean triggerDuringSeed,
-                                          @JsonProperty("phase")
-                                       Phase phase,
                                           @JsonProperty("trigger")
                                        TriggerChecker triggerChecker,
                                           @JsonProperty("requires")
@@ -34,8 +29,7 @@ public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
                                           @JsonProperty("effect")
                                           @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                           List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
-        super(RequiredType.OPTIONAL, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects,
-                triggerDuringSeed);
+        super(text, limitPerTurn, triggerChecker, requirements, costs, effects, triggerDuringSeed);
     }
 
     @Override
@@ -47,7 +41,5 @@ public class OptionalTriggerActionBlueprint extends TriggerActionBlueprint {
         }
         return null;
     }
-
-    public RequiredType getRequiredType() { return _requiredType; }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/RequiredTriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/RequiredTriggerActionBlueprint.java
@@ -21,6 +21,8 @@ public class RequiredTriggerActionBlueprint extends TriggerActionBlueprint {
                                        String text,
                                           @JsonProperty(value="limitPerTurn", defaultValue="0")
                                        int limitPerTurn,
+                                          @JsonProperty(value="triggerDuringSeed", required = true)
+                                      boolean triggerDuringSeed,
                                           @JsonProperty("phase")
                                        Phase phase,
                                           @JsonProperty("trigger")
@@ -33,7 +35,8 @@ public class RequiredTriggerActionBlueprint extends TriggerActionBlueprint {
                                           @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                           @JsonProperty("effect")
                                        List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
-        super(RequiredType.REQUIRED, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects);
+        super(RequiredType.REQUIRED, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects,
+                triggerDuringSeed);
     }
 
     public RequiredTriggerAction createAction(PhysicalCard card) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/RequiredTriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/RequiredTriggerActionBlueprint.java
@@ -10,8 +10,6 @@ import com.gempukku.stccg.cards.InvalidCardDefinitionException;
 import com.gempukku.stccg.requirement.Requirement;
 import com.gempukku.stccg.requirement.trigger.TriggerChecker;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
-import com.gempukku.stccg.common.filterable.Phase;
-import com.gempukku.stccg.common.filterable.RequiredType;
 
 import java.util.List;
 
@@ -23,8 +21,6 @@ public class RequiredTriggerActionBlueprint extends TriggerActionBlueprint {
                                        int limitPerTurn,
                                           @JsonProperty(value="triggerDuringSeed", required = true)
                                       boolean triggerDuringSeed,
-                                          @JsonProperty("phase")
-                                       Phase phase,
                                           @JsonProperty("trigger")
                                        TriggerChecker triggerChecker,
                                           @JsonProperty("requires")
@@ -35,18 +31,13 @@ public class RequiredTriggerActionBlueprint extends TriggerActionBlueprint {
                                           @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                                           @JsonProperty("effect")
                                        List<SubActionBlueprint> effects) throws InvalidCardDefinitionException {
-        super(RequiredType.REQUIRED, text, limitPerTurn, phase, triggerChecker, requirements, costs, effects,
-                triggerDuringSeed);
-    }
-
-    public RequiredTriggerAction createAction(PhysicalCard card) {
-        return new RequiredTriggerAction(card);
+        super(text, limitPerTurn, triggerChecker, requirements, costs, effects, triggerDuringSeed);
     }
 
     @Override
     protected RequiredTriggerAction createActionAndAppendToContext(PhysicalCard card, ActionContext actionContext) {
         if (isValid(actionContext)) {
-            RequiredTriggerAction action = createAction(card);
+            RequiredTriggerAction action = new RequiredTriggerAction(card);
             appendActionToContext(action, actionContext);
             return action;
         }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/SeedCardActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/SeedCardActionBlueprint.java
@@ -14,7 +14,7 @@ public class SeedCardActionBlueprint extends DefaultActionBlueprint {
     public SeedCardActionBlueprint(@JsonProperty(value = "where", required = true)
                                 Zone seedToZone
     ) {
-        super("Seed card", 0, null);
+        super("Seed card", 0);
         _seedToZone = seedToZone;
     }
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
@@ -11,15 +11,12 @@ import java.util.List;
 
 public abstract class TriggerActionBlueprint extends DefaultActionBlueprint {
 
-    private final RequiredType _requiredType;
-
-    protected TriggerActionBlueprint(RequiredType requiredType, String text, int limitPerTurn, Phase phase,
+    protected TriggerActionBlueprint(String text, int limitPerTurn,
                                      TriggerChecker triggerChecker, List<Requirement> requirements,
                                      List<SubActionBlueprint> costs, List<SubActionBlueprint> effects,
                                      boolean triggerDuringSeed)
             throws InvalidCardDefinitionException {
-        super(text, limitPerTurn, phase);
-        _requiredType = requiredType;
+        super(text, limitPerTurn);
         if (requirements != null) {
             _requirements.addAll(requirements);
         }
@@ -31,8 +28,5 @@ public abstract class TriggerActionBlueprint extends DefaultActionBlueprint {
         }
         addCostsAndEffects(costs, effects);
     }
-
-
-    public RequiredType getRequiredType() { return _requiredType; }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
@@ -3,6 +3,7 @@ package com.gempukku.stccg.actions.blueprints;
 import com.gempukku.stccg.cards.InvalidCardDefinitionException;
 import com.gempukku.stccg.common.filterable.Phase;
 import com.gempukku.stccg.common.filterable.RequiredType;
+import com.gempukku.stccg.requirement.PlayPhaseRequirement;
 import com.gempukku.stccg.requirement.Requirement;
 import com.gempukku.stccg.requirement.trigger.TriggerChecker;
 
@@ -14,12 +15,21 @@ public abstract class TriggerActionBlueprint extends DefaultActionBlueprint {
 
     protected TriggerActionBlueprint(RequiredType requiredType, String text, int limitPerTurn, Phase phase,
                                      TriggerChecker triggerChecker, List<Requirement> requirements,
-                                     List<SubActionBlueprint> costs, List<SubActionBlueprint> effects)
+                                     List<SubActionBlueprint> costs, List<SubActionBlueprint> effects,
+                                     boolean triggerDuringSeed)
             throws InvalidCardDefinitionException {
         super(text, limitPerTurn, phase);
         _requiredType = requiredType;
-        addRequirement(triggerChecker);
-        processRequirementsCostsAndEffects(requirements, costs, effects);
+        if (requirements != null) {
+            _requirements.addAll(requirements);
+        }
+        if (triggerChecker != null) {
+            _requirements.add(triggerChecker);
+        }
+        if (!triggerDuringSeed) {
+            _requirements.add(new PlayPhaseRequirement());
+        }
+        addCostsAndEffects(costs, effects);
     }
 
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
@@ -14,7 +14,7 @@ public abstract class TriggerActionBlueprint extends DefaultActionBlueprint {
                                      List<SubActionBlueprint> costs, List<SubActionBlueprint> effects,
                                      boolean triggerDuringSeed)
             throws InvalidCardDefinitionException {
-        super(text, limitPerTurn);
+        super(text, limitPerTurn, costs, effects);
         if (requirements != null) {
             _requirements.addAll(requirements);
         }
@@ -24,7 +24,6 @@ public abstract class TriggerActionBlueprint extends DefaultActionBlueprint {
         if (!triggerDuringSeed) {
             _requirements.add(new PlayPhaseRequirement());
         }
-        addCostsAndEffects(costs, effects);
     }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/TriggerActionBlueprint.java
@@ -1,8 +1,6 @@
 package com.gempukku.stccg.actions.blueprints;
 
 import com.gempukku.stccg.cards.InvalidCardDefinitionException;
-import com.gempukku.stccg.common.filterable.Phase;
-import com.gempukku.stccg.common.filterable.RequiredType;
 import com.gempukku.stccg.requirement.PlayPhaseRequirement;
 import com.gempukku.stccg.requirement.Requirement;
 import com.gempukku.stccg.requirement.trigger.TriggerChecker;

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/CardBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/CardBlueprint.java
@@ -360,12 +360,6 @@ public class CardBlueprint {
         _optionalInHandTriggers.add(actionBlueprint);
     }
 
-    public void appendTrigger(TriggerActionBlueprint actionSource) {
-        RequiredType requiredType = actionSource.getRequiredType();
-        _afterTriggers.computeIfAbsent(requiredType, k -> new LinkedList<>());
-        _afterTriggers.get(requiredType).add(actionSource);
-    }
-
     public void appendPlayRequirement(Requirement requirement) {
         if (_playRequirements == null)
             _playRequirements = new LinkedList<>();

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/CardBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/cards/blueprints/CardBlueprint.java
@@ -607,7 +607,6 @@ public class CardBlueprint {
         return _shipClass;
     }
 
-
     public PhysicalCard createPhysicalCard(ST1EGame st1egame, int cardId, Player player) {
         return switch(_cardType) {
             case EQUIPMENT -> new PhysicalReportableCard1E(st1egame, cardId, player, this);

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/requirement/PlayPhaseRequirement.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/requirement/PlayPhaseRequirement.java
@@ -1,0 +1,14 @@
+package com.gempukku.stccg.requirement;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gempukku.stccg.cards.ActionContext;
+import com.gempukku.stccg.common.filterable.Phase;
+import com.gempukku.stccg.evaluator.ValueSource;
+
+public class PlayPhaseRequirement implements Requirement {
+
+    public boolean accepts(ActionContext actionContext) {
+        Phase currentPhase = actionContext.getGame().getCurrentPhase();
+        return currentPhase != null && !currentPhase.isSeedPhase();
+    }
+}

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/requirement/PlayPhaseRequirement.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/requirement/PlayPhaseRequirement.java
@@ -1,9 +1,7 @@
 package com.gempukku.stccg.requirement;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gempukku.stccg.cards.ActionContext;
 import com.gempukku.stccg.common.filterable.Phase;
-import com.gempukku.stccg.evaluator.ValueSource;
 
 public class PlayPhaseRequirement implements Requirement {
 


### PR DESCRIPTION
Fixing bug where Continuing Mission extra card draw was allowed during the seed phase (for instance, as a reaction to downloading personnel with Assign Mission Specialists).

Achieved by adding a "triggerDuringSeed" parameter to trigger actions in the JSON blueprints. For now, this parameter is required to be specified in the JSON for all cards.

Future potential related work not included in this PR:
- Unit tests for the triggerDuringSeed parameter. Right now building tests for server code is a huge pain. Will pivot to streamlining this process next.
- Similar fix for card definitions written in Java. There are only a handful of cards that allow response actions written in Java (like Surprise Party) and the end goal is to move them into JSON. Will review these after building in some better test functionality.
- Fix of the other bug in Continuing Mission (where it's allowed to do a card draw more than once per turn). This will be a more involved fix.