### PR TITLE
Fix UI crash when carddata is null since the div no longer exists.

### DIFF
--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/gameAnimations.js
@@ -1027,14 +1027,16 @@ export default class GameAnimations {
             function () {
                 let cardData = $(this).data("card");
                 let index = -1;
-                for (let i = 0; i < cardData.attachedCards.length; i++)
+                if (cardData != null) {
+                    for (let i = 0; i < cardData.attachedCards.length; i++)
                     if (cardData.attachedCards[i].data("card").cardId == cardId) {
                         index = i;
                         break;
                     }
-                if (index != -1) {
-                    cardData.attachedCards.splice(index, 1);
-                    getCardDivFromId(cardId).data("card").attachedToCard = null;
+                    if (index != -1) {
+                        cardData.attachedCards.splice(index, 1);
+                        getCardDivFromId(cardId).data("card").attachedToCard = null;
+                    }
                 }
             }
         );


### PR DESCRIPTION
Fix issue when testing dilemmas on `main` where the UI would crash attempting to remove an attached card div that didn't appear on the table (face down dilemma). It was recoverable after a refresh from both players, but it did cause the dreaded error box to appear.