### PR TITLE
Requested game state changes

### DIFF
--- a/gemp-module/gamestate-example.hjson
+++ b/gemp-module/gamestate-example.hjson
@@ -35,9 +35,9 @@
                 at the same time. If player2 has signaled they are finished, playersParticipating will only have
                 player1. */
     },
-    "players": [
-        // Information specific to a player. This array will have a similar JSON object for each player in the game.
-        {
+    "playerMap": {
+        // Information specific to a player. Map using the "playerId" field as a key.
+        "player2": {
             "playerId": "player2",
             "score": 0, // Player score. As of 1/25/25, no distinction between bonus and non-bonus points.
             "decked": false, // Tribbles only
@@ -63,11 +63,15 @@
                     "cardIds": [6,-99] // -99 here most likely represents a hidden agenda card
                 },
                 // etc.
-                // 1E uses DRAW_DECK, DISCARD, CORE, MISSIONS_PILE, REMOVED, HAND, and SEED_DECK.
+                // 1E uses DRAW_DECK, DISCARD, CORE, MISSIONS_PILE, REMOVED, HAND, POINT_AREA, and SEED_DECK.
                 // Tribbles uses DRAW_DECK, DISCARD, and PLAY_PILE.
         },
         // etc. for each player
     ],
+    "players": [
+        /* This item has been deprecated. The members of this list are in the same format as the
+            values in the new "playerMap" map. */
+    ]
     "playerOrder": {
         // Class members for the value in GameState._playerOrder
         "firstPlayer": "player2", // Player ID for player with first turn of the game
@@ -129,13 +133,34 @@
         // etc.
     },
     "spacelineLocations": [
-        /* List of spaceline locations for 1E game. This list in order from left to right.
-                    (As of 1/25/25, both players see the spaceline in the same left-to-right order.)
-            The locationId field is unique to each mission location and referenced by other objects, like cards
-                and away teams. If the spaceline is reorganized (for example, using Blade of Tkon), the locationId
-                values will not change, but the order of this list will.
+        /* This item is being deprecated. The members of this array are in the same format as the values
+            in the "gameLocations" map. The order of this array is in the same order as the
+            "spacelineElements" array. */
+    ]
+    "spacelineElements": [
+        /* List of elements in 1E spacelines. List is in order from left to right.
+            Contains two types of elements: locations and non-location cards.
+            Locations can be looked up by locationId in the gameLocations array, and non-location cards can be
+            looked up by cardId in the cardsInGame (or visibleCardsInGame) array.
             */
         {
+            "type": "location",
+            "locationId": 1,
+            "quadrant": "ALPHA"
+        },
+        {
+            "type": "card",
+            "cardId": 1,
+            "quadrant": "ALPHA"
+        }
+    ],
+    "gameLocations": [
+        /* Map of locations in the game by locationId.
+            The locationId field is unique to each mission location and referenced by other objects, like cards
+                and away teams. If the spaceline is reorganized (for example, using Blade of Tkon), the locationId
+                values will not change.
+            */
+        "1": {
             "locationId": 1,
             "quadrant": "ALPHA", // ALPHA, DELTA, GAMMA, MIRROR
             "locationName": "Gravesworld", // There may be multiple locations with the same name if universal
@@ -147,7 +172,7 @@
             "seedCardCount": 2,
             "seedCardIds": [27,28] // This property is not shown in player-specific game states
         },
-        {
+        "2": {
             "locationId": 2,
             "quadrant": "ALPHA",
             "region": "ROMULUS_SYSTEM", // There will not be a region item if the location is not in one

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/discard/RemoveDilemmaFromGameAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/discard/RemoveDilemmaFromGameAction.java
@@ -8,6 +8,7 @@ import com.gempukku.stccg.actions.targetresolver.FixedCardResolver;
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.ST1EGame;
+import com.gempukku.stccg.gamestate.GameLocation;
 import com.gempukku.stccg.gamestate.MissionLocation;
 import com.gempukku.stccg.gamestate.ST1EGameState;
 
@@ -34,8 +35,8 @@ public class RemoveDilemmaFromGameAction extends ActionyAction {
             ST1EGameState gameState = stGame.getGameState();
             PhysicalCard cardToRemove = _cardTarget.getCard();
 
-            for (MissionLocation mission : gameState.getSpacelineLocations()) {
-                if (mission.getSeedCards().contains(cardToRemove)) {
+            for (GameLocation location : gameState.getOrderedSpacelineLocations()) {
+                if (location instanceof MissionLocation mission && mission.getSeedCards().contains(cardToRemove)) {
                     mission.removeSeedCard(cardToRemove);
                 }
             }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/movecard/FlyShipAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/movecard/FlyShipAction.java
@@ -12,7 +12,6 @@ import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.game.ST1EGame;
 import com.gempukku.stccg.gamestate.GameLocation;
-import com.gempukku.stccg.gamestate.MissionLocation;
 import com.gempukku.stccg.player.Player;
 import com.gempukku.stccg.player.PlayerNotFoundException;
 import com.google.common.collect.Iterables;
@@ -33,17 +32,17 @@ public class FlyShipAction extends ActionyAction implements TopLevelSelectableAc
         super(cardGame, player, ActionType.FLY_SHIP);
         _flyingCard = flyingCard;
         _destinationOptions = new LinkedList<>();
-            // TODO - Include non-mission cards in location options (like Gaps in Normal Space)
-        List<MissionLocation> allLocations = cardGame.getGameState().getSpacelineLocations();
+        List<GameLocation> allLocations = cardGame.getGameState().getOrderedSpacelineLocations();
         GameLocation currentLocation = _flyingCard.getGameLocation(cardGame);
                 // TODO - Does not include logic for inter-quadrant flying (e.g. through wormholes)
-        for (MissionLocation location : allLocations) {
+        for (GameLocation location : allLocations) {
             if (location.isInSameQuadrantAs(currentLocation) && location != currentLocation) {
                 int rangeNeeded = currentLocation.getDistanceToLocation(cardGame, location, player);
                 if (rangeNeeded <= _flyingCard.getRangeAvailable(cardGame)) {
                     PhysicalCard destination = location.getMissionForPlayer(player.getPlayerId());
-                    _destinationOptions.add(destination);
-                    _destinationOptions.add(location.getMissionForPlayer(player.getPlayerId()));
+                    if (destination != null) {
+                        _destinationOptions.add(destination);
+                    }
                 }
             }
         }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/placecard/PlaceCardOnMissionAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/placecard/PlaceCardOnMissionAction.java
@@ -53,9 +53,10 @@ public class PlaceCardOnMissionAction extends ActionyAction {
                 _cardBeingPlaced.setLocation(cardGame, mission);
                 gameState.addCardToZone(cardGame, _cardBeingPlaced, Zone.AT_LOCATION, _actionContext);
 
-                for (MissionLocation spacelineLocation : gameState.getSpacelineLocations()) {
-                    if (spacelineLocation.getSeedCards().contains(_cardBeingPlaced)) {
-                        spacelineLocation.removeSeedCard(_cardBeingPlaced);
+                for (GameLocation spacelineLocation : gameState.getOrderedSpacelineLocations()) {
+                    if (spacelineLocation instanceof MissionLocation missionLoc &&
+                            missionLoc.getSeedCards().contains(_cardBeingPlaced)) {
+                        missionLoc.removeSeedCard(_cardBeingPlaced);
                     }
                 }
                 setAsSuccessful();

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/SeedMissionCardAction.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/playcard/SeedMissionCardAction.java
@@ -12,6 +12,7 @@ import com.gempukku.stccg.common.filterable.Zone;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.game.ST1EGame;
+import com.gempukku.stccg.gamestate.GameLocation;
 import com.gempukku.stccg.gamestate.MissionLocation;
 import com.gempukku.stccg.gamestate.ST1EGameState;
 
@@ -66,19 +67,20 @@ public class SeedMissionCardAction extends PlayCardAction {
                     !_cardEnteringPlay.getBlueprint().isUniversal();
 
             gameState.removeCardsFromZoneWithoutSendingToClient(game, List.of(_cardEnteringPlay));
-            List<MissionLocation> spaceline = gameState.getSpacelineLocations();
+            List<GameLocation> spaceline = gameState.getOrderedSpacelineLocations();
 
             try {
                 if (sharedMission) {
-                    MissionLocation location = spaceline.get(_locationZoneIndex);
-                    List<MissionCard> missionsAtLocation = location.getMissionCards();
-                    if (missionsAtLocation.size() != 1 ||
-                            Objects.equals(missionsAtLocation.getFirst().getOwnerName(), mission.getOwnerName()))
-                        throw new InvalidGameLogicException("Cannot seed " + mission.getTitle() + " because " +
-                                mission.getOwnerName() + " already has a mission at " +
-                                mission.getBlueprint().getLocation());
-                    location.addMission(game, mission);
-                    gameState.addCardToZone(game, mission, Zone.SPACELINE, _actionContext);
+                    if (spaceline.get(_locationZoneIndex) instanceof MissionLocation location) {
+                        List<MissionCard> missionsAtLocation = location.getMissionCards();
+                        if (missionsAtLocation.size() != 1 ||
+                                Objects.equals(missionsAtLocation.getFirst().getOwnerName(), mission.getOwnerName()))
+                            throw new InvalidGameLogicException("Cannot seed " + mission.getTitle() + " because " +
+                                    mission.getOwnerName() + " already has a mission at " +
+                                    mission.getBlueprint().getLocation());
+                        location.addMission(game, mission);
+                        gameState.addCardToZone(game, mission, Zone.SPACELINE, _actionContext);
+                    }
                 }
                 else {
                     int newLocationId = gameState.getNextLocationId();

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/PlayFacilityResolver.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/PlayFacilityResolver.java
@@ -31,7 +31,7 @@ public class PlayFacilityResolver implements ActionTargetResolver {
     public PlayFacilityResolver(ST1EGame stGame, FacilityCard facilityCard, CardFilter additionalDestinationFilter) {
         _cardEnteringPlay = facilityCard;
         _performingPlayerName = _cardEnteringPlay.getOwnerName();
-        for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
             try {
                 MissionCard missionCard = location.getMissionForPlayer(facilityCard.getOwnerName());
                 boolean canPlayHere = stGame.getRules().isLocationValidPlayCardDestinationPerRules(

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/SeedMissionTargetResolver.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/SeedMissionTargetResolver.java
@@ -9,7 +9,7 @@ import com.gempukku.stccg.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.game.ST1EGame;
-import com.gempukku.stccg.gamestate.MissionLocation;
+import com.gempukku.stccg.gamestate.GameLocation;
 import com.gempukku.stccg.gamestate.ST1EGameState;
 
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ public class SeedMissionTargetResolver implements ActionTargetResolver {
                     boolean sharedMission = gameState.indexOfLocation(missionLocationName, quadrant) != null &&
                             !_cardEnteringPlay.getBlueprint().isUniversal();
 
-                    List<MissionLocation> spacelineLocations = gameState.getSpacelineLocations();
+                    List<GameLocation> spacelineLocations = gameState.getOrderedSpacelineLocations();
                     if (sharedMission) {
                         possibleIndices.add(gameState.indexOfLocation(missionLocationName, quadrant));
                     } else if (spacelineLocations.isEmpty()) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/DestinationBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/DestinationBlueprint.java
@@ -19,7 +19,7 @@ public class DestinationBlueprint {
 
     public Collection<MissionLocation> getDestinationOptions(ST1EGame stGame, String performingPlayerName) {
         Collection<MissionLocation> result = new ArrayList<>();
-        for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
             if (location.hasMatchingAffiliationIcon(stGame, performingPlayerName, List.of(_affiliation))) {
                 result.add(location);
             }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/GameLocation.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/GameLocation.java
@@ -2,9 +2,10 @@ package com.gempukku.stccg.gamestate;
 
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
 import com.gempukku.stccg.common.filterable.Quadrant;
+import com.gempukku.stccg.common.filterable.Region;
 import com.gempukku.stccg.game.InvalidGameLogicException;
-import com.gempukku.stccg.player.Player;
 import com.gempukku.stccg.game.ST1EGame;
+import com.gempukku.stccg.player.Player;
 
 public interface GameLocation {
 
@@ -24,7 +25,12 @@ public interface GameLocation {
     boolean isHomeworld();
 
     boolean hasCardSeededUnderneath(PhysicalCard card);
+    boolean isInRegion(Region region);
+    int getSpan(Player player) throws InvalidGameLogicException;
 
     int getLocationId();
 
+    boolean isInSameQuadrantAs(GameLocation currentLocation);
+
+    PhysicalCard getMissionForPlayer(String playerId) throws InvalidGameLogicException;
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/GameState.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/GameState.java
@@ -34,12 +34,16 @@ import java.util.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(value = { "performedActions", "phasesInOrder" }, allowGetters = true)
-@JsonIncludeProperties({ "currentPhase", "phasesInOrder", "currentProcess", "playerOrder", "cardsInGame", "players", "spacelineLocations",
-        "awayTeams", "actions", "performedActions", "playerClocks", "actionLimits", "modifiers" })
-@JsonPropertyOrder({ "currentPhase", "phasesInOrder", "currentProcess", "playerOrder", "cardsInGame", "players", "spacelineLocations",
-        "awayTeams", "actions", "performedActions", "playerClocks", "actionLimits", "modifiers" })
+@JsonIncludeProperties({ "currentPhase", "phasesInOrder", "currentProcess", "playerOrder", "cardsInGame", "players", "playerMap", "spacelineLocations",
+        "awayTeams", "actions", "performedActions", "playerClocks", "actionLimits", "modifiers", "gameLocations", "spacelineElements",
+"versionNumber" })
+@JsonPropertyOrder({ "currentPhase", "phasesInOrder", "currentProcess", "playerOrder", "cardsInGame", "players", "playerMap", "spacelineLocations",
+        "awayTeams", "actions", "performedActions", "playerClocks", "actionLimits", "modifiers", "gameLocations", "spacelineElements",
+"versionNumber" })
 public abstract class GameState {
 
+    @JsonProperty("versionNumber")
+    protected final String VERSION_NUMBER = "1.1.0";
     Phase _currentPhase;
     PlayerOrder _playerOrder;
     protected final Map<Integer, PhysicalCard> _allCards = new HashMap<>();
@@ -55,6 +59,7 @@ public abstract class GameState {
     private final Map<String, PlayerClock> _playerClocks;
     @JsonProperty("players")
     List<Player> _players = new ArrayList<>();
+
     private final Map<String, AwaitingDecision> _awaitingDecisionMap = new HashMap<>();
     private int nextDecisionId = 1;
 
@@ -429,6 +434,15 @@ public abstract class GameState {
 
     public Set<String> getUsersPendingDecision() {
         return _awaitingDecisionMap.keySet();
+    }
+
+    @JsonProperty("playerMap")
+    private Map<String, Player> getPlayerMap() {
+        Map<String, Player> result = new HashMap<>();
+        for (Player player : _players) {
+            result.put(player.getPlayerId(), player);
+        }
+        return result;
     }
 
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/LocationSpacelineIndex.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/LocationSpacelineIndex.java
@@ -1,0 +1,37 @@
+package com.gempukku.stccg.gamestate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gempukku.stccg.common.filterable.Quadrant;
+
+public class LocationSpacelineIndex implements SpacelineIndex {
+
+    private final int _locationId;
+
+    private final Quadrant _quadrant;
+
+    @JsonCreator
+    public LocationSpacelineIndex(
+            @JsonProperty("locationId")
+            int locationId,
+            @JsonProperty("quadrant")
+            Quadrant quadrant) {
+        _locationId = locationId;
+        _quadrant = quadrant;
+    }
+
+    public LocationSpacelineIndex(MissionLocation location) {
+        _locationId = location.getLocationId();
+        _quadrant = location.getQuadrant();
+    }
+
+    @Override
+    public Quadrant getQuadrant() {
+        return _quadrant;
+    }
+
+    @JsonProperty("locationId")
+    public int getLocationId() {
+        return _locationId;
+    }
+}

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/MissionLocation.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/MissionLocation.java
@@ -154,7 +154,7 @@ public class MissionLocation implements GameLocation {
             LOGGER.error(errorMessage);
             throw new InvalidGameLogicException("Tried to calculate span between quadrants");
         } else {
-            List<MissionLocation> spaceline = cardGame.getGameState().getSpacelineLocations();
+            List<GameLocation> spaceline = cardGame.getGameState().getOrderedSpacelineLocations();
             int startingIndex = spaceline.indexOf(this);
             int endingIndex = spaceline.indexOf(location);
             int distance = 0;
@@ -174,11 +174,7 @@ public class MissionLocation implements GameLocation {
         }
     }
 
-    public int getLocationZoneIndex(ST1EGame cardGame) {
-        return cardGame.getGameState().getSpacelineLocations().indexOf(this);
-    }
-
-    private int getSpan(Player player) throws InvalidGameLogicException {
+    public int getSpan(Player player) throws InvalidGameLogicException {
         MissionCard card = getMissionForPlayer(player.getPlayerId());
         if (card.isOwnedBy(player.getPlayerId()))
             return card.getBlueprint().getOwnerSpan();
@@ -416,6 +412,10 @@ public class MissionLocation implements GameLocation {
 
     public boolean isInSameQuadrantAs(GameLocation currentLocation) {
         return currentLocation.isInQuadrant(_quadrant);
+    }
+
+    public boolean isInRegion(Region region) {
+        return _region == region;
     }
 
     public boolean wasSeededBy(String playerName) {

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/NonLocationSpacelineIndex.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/NonLocationSpacelineIndex.java
@@ -1,0 +1,34 @@
+package com.gempukku.stccg.gamestate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
+import com.gempukku.stccg.common.filterable.Quadrant;
+
+public class NonLocationSpacelineIndex implements SpacelineIndex {
+
+    @JsonProperty("cardId")
+    private final int _cardId;
+
+    private final Quadrant _quadrant;
+
+    @JsonCreator
+    public NonLocationSpacelineIndex(
+            @JsonProperty("cardId")
+            int cardId,
+            @JsonProperty("quadrant")
+            Quadrant quadrant) {
+        _cardId = cardId;
+        _quadrant = quadrant;
+    }
+
+    public NonLocationSpacelineIndex(PhysicalCard card, Quadrant quadrant) {
+        _cardId = card.getCardId();
+        _quadrant = quadrant;
+    }
+
+    @Override
+    public Quadrant getQuadrant() {
+        return _quadrant;
+    }
+}

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/NullLocation.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/NullLocation.java
@@ -2,6 +2,7 @@ package com.gempukku.stccg.gamestate;
 
 import com.gempukku.stccg.cards.physicalcard.PhysicalCard;
 import com.gempukku.stccg.common.filterable.Quadrant;
+import com.gempukku.stccg.common.filterable.Region;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.player.Player;
 import com.gempukku.stccg.game.ST1EGame;
@@ -43,7 +44,27 @@ public class NullLocation implements GameLocation {
     }
 
     @Override
+    public boolean isInRegion(Region region) {
+        return false;
+    }
+
+    @Override
+    public int getSpan(Player player) throws InvalidGameLogicException {
+        return 0;
+    }
+
+    @Override
     public int getLocationId() {
         return -999;
+    }
+
+    @Override
+    public boolean isInSameQuadrantAs(GameLocation currentLocation) {
+        return false;
+    }
+
+    @Override
+    public PhysicalCard getMissionForPlayer(String playerId) throws InvalidGameLogicException {
+        throw new InvalidGameLogicException("No missions at this location");
     }
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/ST1EGameState.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/ST1EGameState.java
@@ -32,6 +32,8 @@ public class ST1EGameState extends GameState {
     @JsonProperty("awayTeams")
     final List<AwayTeam> _awayTeams = new ArrayList<>();
     private int _nextAttemptingUnitId = 1;
+
+    @JsonProperty("gameLocations")
     private final Map<Integer, GameLocation> _locationIds = new HashMap<>();
 
     @SuppressWarnings("unused")
@@ -221,7 +223,8 @@ public class ST1EGameState extends GameState {
         return null;
     }
 
-    public List<MissionLocation> getSpacelineLocations() { return _spacelineLocations; }
+    @JsonIgnore
+    public List<MissionLocation> getUnorderedMissionLocations() { return _spacelineLocations; }
 
 
     public List<AwayTeam> getAwayTeams() {
@@ -323,4 +326,23 @@ public class ST1EGameState extends GameState {
         return null;
     }
 
+    public List<GameLocation> getOrderedSpacelineLocations() {
+        List<GameLocation> result = new ArrayList<>();
+        for (SpacelineIndex index : getSpacelineElements()) {
+            if (index instanceof LocationSpacelineIndex locationIndex) {
+                GameLocation location = _locationIds.get(locationIndex.getLocationId());
+                result.add(location);
+            }
+        }
+        return result;
+    }
+
+    @JsonProperty("spacelineElements")
+    public List<SpacelineIndex> getSpacelineElements() {
+        List<SpacelineIndex> result = new ArrayList<>();
+        for (MissionLocation mission : _spacelineLocations) {
+            result.add(new LocationSpacelineIndex(mission));
+        }
+        return result;
+    }
 }

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/SpacelineIndex.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/gamestate/SpacelineIndex.java
@@ -1,0 +1,16 @@
+package com.gempukku.stccg.gamestate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.gempukku.stccg.common.filterable.Quadrant;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = LocationSpacelineIndex.class, name = "location"),
+        @JsonSubTypes.Type(value = NonLocationSpacelineIndex.class, name = "card")
+})
+public interface SpacelineIndex {
+    @JsonProperty("quadrant")
+    public Quadrant getQuadrant();
+}

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseOpponentsMissionsProcess.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseOpponentsMissionsProcess.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.gempukku.stccg.cards.physicalcard.MissionCard;
 import com.gempukku.stccg.game.*;
 import com.gempukku.stccg.gamestate.MissionLocation;
-import com.gempukku.stccg.player.Player;
-import com.gempukku.stccg.player.PlayerNotFoundException;
 import com.gempukku.stccg.processes.GameProcess;
 
 import java.beans.ConstructorProperties;
@@ -26,7 +24,7 @@ public class DilemmaSeedPhaseOpponentsMissionsProcess extends DilemmaSeedPhasePr
     @Override
     List<MissionLocation> getAvailableMissions(ST1EGame stGame, String playerId) {
         List<MissionLocation> result = new ArrayList<>();
-        for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
             MissionCard mission = location.getMissionCards().getFirst();
             if (location.getMissionCards().size() == 1 && !Objects.equals(mission.getOwnerName(), playerId))
                 result.add(location);
@@ -39,7 +37,7 @@ public class DilemmaSeedPhaseOpponentsMissionsProcess extends DilemmaSeedPhasePr
     public GameProcess getNextProcess(DefaultGame cardGame) throws InvalidGameLogicException {
         ST1EGame stGame = getST1EGame(cardGame);
         if (_playersParticipating.isEmpty()) {
-            for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+            for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
                 location.seedPreSeedsForOpponentsMissions(cardGame);
             }
             return new DilemmaSeedPhaseSharedMissionsProcess(stGame);

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseSharedMissionsProcess.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseSharedMissionsProcess.java
@@ -27,7 +27,7 @@ public class DilemmaSeedPhaseSharedMissionsProcess extends DilemmaSeedPhaseProce
     @Override
     List<MissionLocation> getAvailableMissions(ST1EGame stGame, String playerId) {
         List<MissionLocation> result = new ArrayList<>();
-        for (MissionLocation location: stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location: stGame.getGameState().getUnorderedMissionLocations()) {
             if (location.isSharedMission())
                 result.add(location);
         }
@@ -38,7 +38,7 @@ public class DilemmaSeedPhaseSharedMissionsProcess extends DilemmaSeedPhaseProce
     public GameProcess getNextProcess(DefaultGame cardGame) throws InvalidGameLogicException {
         ST1EGame stGame = getST1EGame(cardGame);
         if (_playersParticipating.isEmpty()) {
-            for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+            for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
                 location.seedPreSeedsForSharedMissions(stGame);
             }
             return new DilemmaSeedPhaseYourMissionsProcess(stGame);

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseYourMissionsProcess.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/processes/st1e/DilemmaSeedPhaseYourMissionsProcess.java
@@ -5,7 +5,6 @@ import com.gempukku.stccg.cards.physicalcard.MissionCard;
 import com.gempukku.stccg.common.filterable.Phase;
 import com.gempukku.stccg.game.*;
 import com.gempukku.stccg.gamestate.MissionLocation;
-import com.gempukku.stccg.player.PlayerNotFoundException;
 import com.gempukku.stccg.processes.GameProcess;
 
 import java.beans.ConstructorProperties;
@@ -27,7 +26,7 @@ public class DilemmaSeedPhaseYourMissionsProcess extends DilemmaSeedPhaseProcess
     @Override
     List<MissionLocation> getAvailableMissions(ST1EGame stGame, String playerId) {
         List<MissionLocation> result = new ArrayList<>();
-        for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
             MissionCard mission = location.getMissionCards().getFirst();
             if (location.getMissionCards().size() == 1 && mission.isOwnedBy(playerId))
                 result.add(location);
@@ -40,7 +39,7 @@ public class DilemmaSeedPhaseYourMissionsProcess extends DilemmaSeedPhaseProcess
     public GameProcess getNextProcess(DefaultGame cardGame) throws InvalidGameLogicException {
         ST1EGame stGame = getST1EGame(cardGame);
         if (_playersParticipating.isEmpty()) {
-            for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+            for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
                 location.seedPreSeedsForYourMissions(cardGame);
             }
             cardGame.setCurrentPhase(Phase.SEED_FACILITY);

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1EPlayCardInPhaseRule.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1EPlayCardInPhaseRule.java
@@ -94,7 +94,7 @@ public class ST1EPlayCardInPhaseRule extends ST1ERule {
     }
 
     public boolean canFacilityBeSeeded(FacilityCard facility, ST1EGame game) {
-        for (MissionLocation location : game.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : game.getGameState().getUnorderedMissionLocations()) {
             boolean canSeedHere = game.getRules().isLocationValidPlayCardDestinationPerRules(
                     game, facility, location, SeedCardAction.class, facility.getOwnerName(),
                     facility.getAffiliationOptions());

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1ERuleSet.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/rules/st1e/ST1ERuleSet.java
@@ -199,7 +199,7 @@ public class ST1ERuleSet extends RuleSet<ST1EGame> {
     public Map<PhysicalCard, List<Affiliation>> getDestinationMapForSeedingFacilityPerRules(
             FacilityCard facility, String performingPlayerName, ST1EGame stGame) {
         Map<PhysicalCard, List<Affiliation>> result = new HashMap<>();
-        for (MissionLocation location : stGame.getGameState().getSpacelineLocations()) {
+        for (MissionLocation location : stGame.getGameState().getUnorderedMissionLocations()) {
             try {
                 Collection<PhysicalCard> facilitiesOwnedByPlayerHere = Filters.filterCardsInPlay(
                         stGame, Filters.owner(performingPlayerName), CardType.FACILITY,

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SeedPhaseTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SeedPhaseTest.java
@@ -46,7 +46,7 @@ public class SeedPhaseTest extends AbstractAtTest {
         autoSeedMissions();
 
         // There should now be 12 missions seeded
-        assertEquals(12, _game.getGameState().getSpacelineLocations().size());
+        assertEquals(12, _game.getGameState().getUnorderedMissionLocations().size());
 
         assertEquals(Phase.SEED_DILEMMA, _game.getCurrentPhase());
         while (_game.getCurrentPhase() == Phase.SEED_DILEMMA)
@@ -69,7 +69,7 @@ public class SeedPhaseTest extends AbstractAtTest {
         initializeGame();
         autoSeedMissions();
 
-        assertEquals(12, _game.getGameState().getSpacelineLocations().size());
+        assertEquals(12, _game.getGameState().getUnorderedMissionLocations().size());
 
         assertEquals(Phase.SEED_DILEMMA, _game.getCurrentPhase());
 

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SharedMissionTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/SharedMissionTest.java
@@ -39,7 +39,7 @@ public class SharedMissionTest extends AbstractAtTest {
         assertTrue(mission2.isInPlay());
 
         assertNotEquals(Phase.SEED_MISSION, _game.getCurrentPhase());
-        List<MissionLocation> locations = _game.getGameState().getSpacelineLocations();
+        List<MissionLocation> locations = _game.getGameState().getUnorderedMissionLocations();
         assertEquals(1, locations.size());
         MissionLocation onlyLocation = locations.getFirst();
         assertEquals(2, onlyLocation.getMissionCards().size());

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/gamestate/GameStateSerializerTest.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/gamestate/GameStateSerializerTest.java
@@ -1,0 +1,91 @@
+package com.gempukku.stccg.gamestate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gempukku.stccg.AbstractAtTest;
+import com.gempukku.stccg.GameTestBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GameStateSerializerTest extends AbstractAtTest {
+
+    private final static String VERSION_NUMBER = "1.1.0";
+
+    @Test
+    public void serializeCompleteTest() throws Exception {
+        GameTestBuilder builder = new GameTestBuilder(_cardLibrary, formatLibrary, _players);
+        _game = builder.getGame();
+        builder.startGame();
+
+        JsonNode gameStateJson = new ObjectMapper().readTree(_game.getGameState().serializeComplete());
+        assertEquals(17, gameStateJson.size());
+        assertTrue(gameStateJson.has("currentPhase"));
+        assertTrue(gameStateJson.has("phasesInOrder"));
+        assertTrue(gameStateJson.has("currentProcess"));
+        assertTrue(gameStateJson.has("playerOrder"));
+        assertTrue(gameStateJson.has("cardsInGame"));
+        assertTrue(gameStateJson.has("players"));
+        assertTrue(gameStateJson.has("playerMap"));
+        assertTrue(gameStateJson.has("spacelineLocations"));
+        assertTrue(gameStateJson.has("awayTeams"));
+        assertTrue(gameStateJson.has("actions"));
+        assertTrue(gameStateJson.has("performedActions"));
+        assertTrue(gameStateJson.has("playerClocks"));
+        assertTrue(gameStateJson.has("actionLimits"));
+        assertTrue(gameStateJson.has("modifiers"));
+        assertTrue(gameStateJson.has("gameLocations"));
+        assertTrue(gameStateJson.has("spacelineElements"));
+        assertTrue(gameStateJson.has("versionNumber"));
+
+        assertEquals(VERSION_NUMBER, gameStateJson.get("versionNumber").textValue());
+    }
+
+    @Test
+    public void serializeForPlayerTest() throws Exception {
+        GameTestBuilder builder = new GameTestBuilder(_cardLibrary, formatLibrary, _players);
+        _game = builder.getGame();
+        builder.startGame();
+
+        JsonNode gameStateJson = new ObjectMapper().readTree(_game.getGameState().serializeForPlayer(P1));
+        assertEquals(15, gameStateJson.size());
+        assertTrue(gameStateJson.has("requestingPlayer"));
+        assertTrue(gameStateJson.has("currentPhase"));
+        assertTrue(gameStateJson.has("phasesInOrder"));
+        assertTrue(gameStateJson.has("playerOrder"));
+        assertTrue(gameStateJson.has("visibleCardsInGame"));
+        assertTrue(gameStateJson.has("players"));
+        assertTrue(gameStateJson.has("playerMap"));
+        assertTrue(gameStateJson.has("spacelineLocations"));
+        assertTrue(gameStateJson.has("awayTeams"));
+        assertTrue(gameStateJson.has("performedActions"));
+        assertTrue(gameStateJson.has("playerClocks"));
+        assertTrue(gameStateJson.has("pendingDecision"));
+        assertTrue(gameStateJson.has("gameLocations"));
+        assertTrue(gameStateJson.has("spacelineElements"));
+        assertTrue(gameStateJson.has("versionNumber"));
+
+        assertEquals(VERSION_NUMBER, gameStateJson.get("versionNumber").textValue());
+    }
+
+    @Test
+    public void spacelineElementsTest() throws Exception {
+        GameTestBuilder builder = new GameTestBuilder(_cardLibrary, formatLibrary, _players);
+        builder.addMission("101_154", "Excavation", P1);
+        _game = builder.getGame();
+        builder.startGame();
+
+        JsonNode gameStateJson = new ObjectMapper().readTree(_game.getGameState().serializeForPlayer(P1));
+        JsonNode elementsJson = gameStateJson.get("spacelineElements");
+        assertTrue(elementsJson.isArray());
+        assertEquals(1, elementsJson.size());
+        JsonNode elementNode = elementsJson.get(0);
+        assertEquals(3, elementNode.size());
+        assertEquals("location", elementNode.get("type").textValue());
+        assertEquals(1, elementNode.get("locationId").intValue());
+        assertEquals("ALPHA", elementNode.get("quadrant").textValue());
+    }
+
+
+}


### PR DESCRIPTION
@andrewd18

Added some new properties to the serialized game state:
- "versionNumber" - serialized game state version number (current version with the changes in this PR is 1.1.0)
- "playerMap" - presumably this will replace the "players" property. Same info, but in a map structure instead of an array.
- "spacelineElements" and "gameLocations" - presumably these will replace the "spacelineLocations" property. "spacelineElements" is pretty brief information in an ordered array to represent the layout of the spaceline. "gameLocations" has all the extra info that you're currently getting in "spacelineLocations".

I updated the gamestate example JSON file, but did not update the "player_state.json" file you've got in the "client" folder. Let me know if we feel a need for some migration assistance in the future when the gamestate versions are updated. At the moment it seems like it'd be overkill, but I'm not opposed to it.


I also left the client code alone in this PR. You'll still be getting "players" and "spacelineLocations" for the foreseeable future, just let me know if you ever remove the client dependence on those items.