### PR TITLE
Assign Mission Specialists bug fix

### DIFF
--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DownloadReportableActionBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/blueprints/DownloadReportableActionBlueprint.java
@@ -10,6 +10,7 @@ import com.gempukku.stccg.actions.targetresolver.ReportMultipleCardsResolver;
 import com.gempukku.stccg.cards.ActionContext;
 import com.gempukku.stccg.cards.InvalidCardDefinitionException;
 import com.gempukku.stccg.common.filterable.Zone;
+import com.gempukku.stccg.filters.YouCanDownloadFilterBlueprint;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 import com.gempukku.stccg.player.PlayerNotFoundException;
@@ -23,8 +24,8 @@ public class DownloadReportableActionBlueprint implements SubActionBlueprint {
 
     DownloadReportableActionBlueprint(@JsonProperty(value = "target")
                                       ReportCardsResolverBlueprint cardTarget) {
+        cardTarget.addReportableFilter(new YouCanDownloadFilterBlueprint());
         _cardTarget = cardTarget;
-
     }
 
     @Override

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/ReportCardsResolverBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/actions/targetresolver/ReportCardsResolverBlueprint.java
@@ -12,9 +12,12 @@ import com.gempukku.stccg.filters.FilterBlueprint;
 import com.gempukku.stccg.game.DefaultGame;
 import com.gempukku.stccg.game.InvalidGameLogicException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ReportCardsResolverBlueprint implements TargetResolverBlueprint {
 
-    private final FilterBlueprint _reportableFilterBlueprint;
+    private FilterBlueprint _reportableFilterBlueprint;
     private final ValueSource _count;
     private final FilterBlueprint _destinationFilterBlueprint;
     private final boolean _differentCardsOnly;
@@ -59,6 +62,13 @@ public class ReportCardsResolverBlueprint implements TargetResolverBlueprint {
     @Override
     public void addFilter(FilterBlueprint... filterBlueprint) {
 
+    }
+
+    public void addReportableFilter(FilterBlueprint... filterBlueprints) {
+        List<FilterBlueprint> newFilters = new ArrayList<>();
+        newFilters.add(_reportableFilterBlueprint);
+        newFilters.addAll(List.of(filterBlueprints));
+        _reportableFilterBlueprint = new AndFilterBlueprint(newFilters);
     }
 
     @Override

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/AndFilterBlueprint.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/filters/AndFilterBlueprint.java
@@ -5,6 +5,7 @@ import com.gempukku.stccg.common.filterable.Filterable;
 import com.gempukku.stccg.game.DefaultGame;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class AndFilterBlueprint implements FilterBlueprint {
@@ -13,6 +14,10 @@ public class AndFilterBlueprint implements FilterBlueprint {
 
     public AndFilterBlueprint(FilterBlueprint... filterBlueprints) {
         _filterBlueprints = filterBlueprints;
+    }
+
+    public AndFilterBlueprint(Collection<FilterBlueprint> filterBlueprints) {
+        _filterBlueprints = filterBlueprints.toArray(new FilterBlueprint[0]);
     }
 
     public CardFilter getFilterable(DefaultGame cardGame, ActionContext actionContext) {

--- a/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
+++ b/gemp-module/gemp-stccg-logic/src/test/java/com/gempukku/stccg/cards/blueprints/Blueprint_109_063_AMS_Test.java
@@ -21,15 +21,19 @@ public class Blueprint_109_063_AMS_Test extends AbstractAtTest {
 
     private FacilityCard outpost;
     private PhysicalCard ams;
-    private PhysicalCard tarses;
-    private PhysicalCard wallace;
+    private PhysicalCard tarses1;
+    private PhysicalCard wallace1;
+    private PhysicalCard tarses2;
+    private PhysicalCard wallace2;
 
     private void initializeGame() throws InvalidGameOperationException, CardNotFoundException {
         GameTestBuilder builder = new GameTestBuilder(_cardLibrary, formatLibrary, _players);
         _game = builder.getGame();
         ams = builder.addSeedDeckCard("109_063", "Assign Mission Specialists", P1);
-        tarses = builder.addDrawDeckCard("101_236", "Simon Tarses", P1);
-        wallace = builder.addDrawDeckCard("101_203", "Darian Wallace", P1);
+        tarses1 = builder.addDrawDeckCard("101_236", "Simon Tarses", P1);
+        wallace1 = builder.addDrawDeckCard("101_203", "Darian Wallace", P1);
+        tarses2 = builder.addDrawDeckCard("101_236", "Simon Tarses", P2);
+        wallace2 = builder.addDrawDeckCard("101_203", "Darian Wallace", P2);
         outpost = builder.addOutpost(Affiliation.FEDERATION, P1); // Federation Outpost
         builder.setPhase(Phase.SEED_FACILITY);
         builder.startGame();
@@ -45,7 +49,10 @@ public class Blueprint_109_063_AMS_Test extends AbstractAtTest {
         useGameText(ams, P1);
         assertNotNull(_game.getAwaitingDecision(P1));
 
-        List<PhysicalCard> specialists = List.of(tarses, wallace);
+
+        List<PhysicalCard> specialists = List.of(tarses1, wallace1);
+        assertTrue(getSelectableCards(P1).containsAll(specialists));
+        assertFalse(getSelectableCards(P1).containsAll(List.of(tarses2, wallace2)));
 
         selectCards(P1, specialists);
         for (PhysicalCard specialist : specialists) {


### PR DESCRIPTION
Fixed bug where Assign Mission Specialists was allowing you to download your opponent's cards. Added logic to this card's unit test to catch if this is allowed in the future.

Issue #249 