### PR TITLE
More 2E card support work

### DIFF
--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set1.json
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set1.json
@@ -16,7 +16,7 @@
             "lore" : "Arrange a cargo transfer at this major commercial shipping center.",
             "affiliation-icons" : "bajoran,federation,ferengi,klingon,romulan",
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01154A.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01154a.jpg"
         },
 		{
             "blueprintId" : "1_155",
@@ -437,7 +437,7 @@
 			"integrity" : 4,
 			"cunning" : 6,
 			"strength" : 5,
-			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01.jpg"
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01250.jpg"
 		},
         {
             "blueprintId" : "1_251",

--- a/gemp-module/gemp-stccg-cards/src/main/resources/cards/set1.json
+++ b/gemp-module/gemp-stccg-cards/src/main/resources/cards/set1.json
@@ -18,6 +18,21 @@
             "span" : 2,
             "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01154A.jpg"
         },
+		{
+            "blueprintId" : "1_155",
+            "title" : "L-S VI",
+            "subtitle" : "Changeling Research",
+            "uniqueness" : "unique",
+            "type" : "mission",
+            "mission-type" : "planet",
+            "quadrant" : "gamma",
+            "point-box" : 45,
+            "mission-requirements" : "2 Exobiology, Geology, 3 Science, and Cunning>42",
+            "lore" : "\"One of the Bajoran science probes recently scanned a planet about six light-years from the wormhole. It picked up some very unique and familiar DNA patterns.\"",
+            "affiliation-icons" : "bajoran,cardassian,federation,romulan",
+            "span" : 2,
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01155a.jpg"
+        },
         {
             "blueprintId" : "1_156",
             "title" : "Edge of Denkiri Arm",
@@ -35,17 +50,18 @@
         },
         {
             "blueprintId" : "1_157",
-            "title" : "Collect Sample",
+            "title" : "Satvintri Cloud",
+			"subtitle" : "Collect Sample",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "space",
             "quadrant" : "alpha",
             "point-box" : 35,
             "mission-requirements" : "Physics, 2 Science, Transporters, and Cunning>34",
-            "lore" : "Gaseous cloud: Beam a sample of this volatile gas aboard your ship and explore possible applications in weapon design.",
+            "lore" : "Beam a sample of this volatile gas aboard your ship and explore possible applications in weapon design.",
             "affiliation-icons" : "cardassian,dominion,ferengi,klingon,romulan",
             "span" : 3,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01157.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01157a.jpg"
         },
         {
             "blueprintId" : "1_161",
@@ -73,13 +89,14 @@
             "headquarters" : "Federation",
             "playable" : "federation+ds9-icon,earth,non-aligned,equipment",
             "region" : "Sector 001",
-            "lore" : "Earth: \"Now there’s something I never get tired of looking at.\"",
+            "lore" : "Earth: \"Now there's something I never get tired of looking at.\"",
             "span" : 2,
             "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01162.jpg"
         },
         {
             "blueprintId" : "1_166",
-            "title" : "Excavation",
+            "title" : "Kurl",
+			"subtitle" : "Excavation",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "planet",
@@ -89,7 +106,7 @@
             "mission-requirements" : "Anthropology, 2 Archaeology, and Cunning>30",
             "point-box" : 30,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01166.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01166a.jpg"
         },
         {
             "blueprintId" : "1_167",
@@ -104,7 +121,7 @@
             "mission-requirements" : "Astrometrics, Leadership, Physics, Science, and Cunning>34",
             "point-box" : 35,
             "span" : 4,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01167.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01167a.jpg"
         },
         {
             "blueprintId" : "1_169",
@@ -119,7 +136,7 @@
             "mission-requirements" : "Engineer, Geology, Cunning>28, and (Acquisition or Law or 2 Treachery)",
             "point-box" : 30,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01169.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01169a.jpg"
         },
         {
             "blueprintId" : "1_170",
@@ -134,7 +151,7 @@
             "mission-requirements" : "Astrometrics, Engineer, Physics, Science, and Cunning>36",
             "point-box" : 35,
             "span" : 3,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01170.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01170a.jpg"
         },
         {
             "blueprintId" : "1_180",
@@ -153,21 +170,23 @@
         },
         {
             "blueprintId" : "1_182",
-            "title" : "Investigate Sighting",
+            "title" : "Beta Stromgren",
+			"subtitle" : "Investigate Sighting",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "space",
             "quadrant" : "alpha",
             "affiliation-icons" : "federation,romulan",
-            "lore" : "Beta Stromgren: \"They call it ‘Tin Man.’ ... Its energy source is unknown. The people who’ve studied the transmissions think it’s a starship. And they’re sure it’s alive. ... No one knows where it came from, or why it’s here. But we’re going to meet it. We’re going to talk to it.\"",
+            "lore" : "Beta Stromgren: \"They call it 'Tin Man.' ... Its energy source is unknown. The people who've studied the transmissions think it's a starship. And they're sure it's alive. ... No one knows where it came from, or why it's here. But we're going to meet it. We're going to talk to it.\"",
             "mission-requirements" : "Exobiology, 2 Treachery, and Cunning>28 or 2 Telepathy and Integrity>29",
             "point-box" : 30,
             "span" : 3,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01182.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01182a.jpg"
         },
         {
             "blueprintId" : "1_185",
-            "title" : "Medical Relief",
+            "title" : "Beta Lankal",
+			"subtitle" : "Medical Relief",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "planet",
@@ -177,11 +196,12 @@
             "mission-requirements" : "Biology, Exobiology, Medical, and Cunning>32",
             "point-box" : 30,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01185.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01185a.jpg"
         },
         {
             "blueprintId" : "1_186",
-            "title" : "Military Exercises",
+            "title" : "Oneamisu Sector",
+			"subtitle" : "Military Exercises",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "space",
@@ -191,7 +211,7 @@
             "mission-requirements" : "Leadership, 2 Officer, Security, and Cunning>34",
             "point-box" : 35,
             "span" : 3,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01186.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01186a.jpg"
         },
         {
             "blueprintId" : "1_191",
@@ -210,21 +230,23 @@
         },
         {
             "blueprintId" : "1_193",
-            "title" : "Quest for the Sword of Kahless",
+            "title" : "Hur'q",
+			"subtitle" : "Quest for the Sword of Kahless",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "planet",
             "quadrant" : "gamma",
             "point-box" : 40,
             "mission-requirements" : "Archaeology, Leadership, 2 Science, Strength>38, and (Honor or Treachery)",
-            "lore" : "Hur’q planet: \"The Hur’q invaded our homeworld over 1,000 years ago. Whatever they could not pillage, they destroyed. They took the Sword and my people have been searching for it ever since.\"",
+            "lore" : "Hur'q planet: \"The Hur'q invaded our homeworld over 1,000 years ago. Whatever they could not pillage, they destroyed. They took the Sword and my people have been searching for it ever since.\"",
             "affiliation-icons" : "cardassian,ferengi,klingon,romulan",
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01193.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01193a.jpg"
         },
         {
             "blueprintId" : "1_200",
-            "title" : "Sensitive Search",
+            "title" : "Nequencia System",
+			"subtitle" : "Sensitive Search",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "planet",
@@ -234,25 +256,27 @@
             "mission-requirements" : "Programming, Security, Cunning>30, and (Acquisition or Honor or Law or Treachery)",
             "point-box" : 30,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01200.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01200a.jpg"
         },
         {
             "blueprintId" : "1_201",
-            "title" : "Study Cometary Cloud",
+            "title" : "Cruses System",
+			"subtitle" : "Study Cometary Cloud",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "space",
             "quadrant" : "alpha",
             "point-box" : 35,
             "mission-requirements" : "Astrometrics, Navigation, Programming, Cunning>34, and (Acquisition or Security)",
-            "lore" : "Cruses system: Collect samples of the unusual particles in this system’s Oort cloud. Conduct research on their military or commercial potential.",
+            "lore" : "Cruses system: Collect samples of the unusual particles in this system's Oort cloud. Conduct research on their military or commercial potential.",
             "affiliation-icons" : "dominion,ferengi,klingon,non-aligned,romulan",
             "span" : 3,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01201.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01201a.jpg"
         },
         {
             "blueprintId" : "1_203",
-            "title" : "Surgery Under Fire",
+            "title" : "Ajilon Prime",
+			"subtitle" : "Surgery Under Fire",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "planet",
@@ -262,11 +286,12 @@
             "mission-requirements" : "Biology, Leadership, Medical, Officer, and Strength>36",
             "point-box" : 35,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01203.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01203a.jpg"
         },
         {
             "blueprintId" : "1_206",
             "title" : "Barzan Wormhole",
+			"subtitle" : "Wormhole Negotiations",
             "uniqueness" : "unique",
             "type" : "mission",
             "mission-type" : "space",
@@ -276,8 +301,144 @@
             "affiliation-icons" : "federation,ferengi,klingon,non-aligned,romulan",
             "point-box" : 45,
             "span" : 2,
-            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01206.jpg"
+            "image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01206a.jpg"
         },
+		{
+			"blueprintId" : "1_207",
+			"title" : "Anara",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 1,
+			"species" : "Bajoran",
+			"icons" : "staff, ds9-icon",
+			"skill-box" : "[*] Engineer [*] Physics [*] Transporters",
+			"lore" : "In the early years following the Occupation, Bajoran tours of duty aboard Deep Space 9 often lasted only a few months. The Militia hoped to train a number of junior officers in skills useful for the rebuilding efforts on Bajor.",
+			"integrity" : 5,
+			"cunning" : 5,
+			"strength" : 4,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01207.jpg"
+		},
+		{
+			"blueprintId" : "1_210",
+			"title" : "Brilgar",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 1,
+			"species" : "Bajoran",
+			"icons" : "staff, ds9-icon",
+			"skill-box" : "[*] Anthropology [*] Law [*] Security",
+			"lore" : "Most improvements to Deep Space 9's security came from knowledge of how Bajorans had defeated it while the station was under Cardassian control.",
+			"integrity" : 5,
+			"cunning" : 5,
+			"strength" : 6,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01210.jpg"
+		},
+		{
+			"blueprintId" : "1_214",
+			"title" : "Jabara",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 1,
+			"species" : "Bajoran",
+			"icons" : "ds9-icon",
+			"skill-box" : "[*] Exobiology [*] Medical [*] Programming",
+			"lore" : "Bajorans on the Infirmary staff proved every bit as reliable as the Starfleet personnel.",
+			"integrity" : 6,
+			"cunning" : 6,
+			"strength" : 4,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01214.jpg"
+		},
+		{
+			"blueprintId" : "1_215",
+			"title" : "Keeve Falor",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 1,
+			"species" : "Bajoran",
+			"icons" : "staff",
+			"skill-box" : "[*] Biology [*] Honor [*] Leadership",
+			"lore" : "\"You were 'innocent bystanders' for decades as the Cardassians took our homes. As they violated and tortured our people in the most hideous ways imaginable. As we were forced to flee.\"",
+			"integrity" : 6,
+			"cunning" : 5,
+			"strength" : 6,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01215.jpg"
+		},
+		{
+			"blueprintId" : "1_219",
+			"title" : "Mora Pol",
+            "subtitle" : "Pioneering Scientist",
+            "uniqueness" : "unique",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 2,
+			"species" : "Bajoran",
+			"icons" : "staff",
+			"skill-box" : "[*] 2 Exobiology [*] Physics [*] 2 Science",
+			"lore" : "\"In science we look for the obvious. We track in a straight line. If something looks too good to be true, it usually isn't true. If there appears to be more to something than meets the eye, there usually is more. We take it step by step.\"",
+			"integrity" : 5,
+			"cunning" : 7,
+			"strength" : 4,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01219.jpg"
+		},
+		{
+			"blueprintId" : "1_227",
+			"title" : "Weld Ram",
+			"type" : "personnel",
+			"affiliation" : "bajoran",
+			"cost" : 1,
+			"species" : "Bajoran",
+			"icons" : "staff",
+			"skill-box" : "[*] Archaeology [*] Geology [*] Science",
+			"lore" : "Member of the Bajoran Institute of Science who accompanied Dr. Mora Pol on an expedition to the Gamma Quadrant.",
+			"integrity" : 5,
+			"cunning" : 5,
+			"strength" : 5,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01227.jpg"
+		},
+		{
+			"blueprintId" : "1_237",
+			"title" : "Emok",
+			"type" : "personnel",
+			"affiliation" : "cardassian",
+			"cost" : 1,
+			"species" : "Cardassian",
+			"icons" : "staff",
+			"skill-box" : "[*] Exobiology [*] Intelligence [*] Medical",
+			"lore" : "\"The Obsidian Order. ... Even the Romulan Tal Shiar can't compete with them when it comes to intelligence gathering and covert operations.\"",
+			"integrity" : 5,
+			"cunning" : 5,
+			"strength" : 5,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01237.jpg"
+		},
+		{
+			"blueprintId" : "1_247",
+			"title" : "Megar",
+			"type" : "personnel",
+			"affiliation" : "cardassian",
+			"cost" : 1,
+			"species" : "Cardassian",
+			"skill-box" : "[*] Anthropology [*] Biology [*] Law",
+			"lore" : "Established over 500 years ago, the Detapa Council ostensibly leads the Cardassian government. Over time, its true power has eroded as the Central Command and Obsidian Order have acted with increasing autonomy.",
+			"integrity" : 5,
+			"cunning" : 5,
+			"strength" : 5,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01247.jpg"
+		},
+		{
+			"blueprintId" : "1_250",
+			"title" : "Rogesh",
+			"type" : "personnel",
+			"affiliation" : "cardassian",
+			"cost" : 2,
+			"species" : "Cardassian",
+			"icons" : "staff",
+			"skill-box" : "[*] Intelligence [*] Navigation [*] Physics [*] Science [*] Treachery",
+			"lore" : "\"...the ever-vigilant eyes and ears of the Cardassian Empire. It is said that a Cardassian citizen cannot sit down to a meal without each dish being duly noted and recorded by the Order.\"",
+			"integrity" : 4,
+			"cunning" : 6,
+			"strength" : 5,
+			"image-url" : "https://www.trekcc.org/2e/cardimages/ST2E-EN01.jpg"
+		},
         {
             "blueprintId" : "1_251",
             "title" : "Altman",
@@ -468,7 +629,7 @@
             "staffing" : "staff,staff,staff",
             "ship-class" : "Excelsior Class",
             "icons" : "earth",
-            "lore" : "Although the transwarp drive experiment of the late 23rd century was a failure, the design of the ship itself was one of Starfleet’s greatest successes. New Excelsior-class ships were still being constructed over 75 years later.",
+            "lore" : "Although the transwarp drive experiment of the late 23rd century was a failure, the design of the ship itself was one of Starfleet's greatest successes. New Excelsior-class ships were still being constructed over 75 years later.",
             "range" : 8,
             "weapons" : 7,
             "shields" : 7,
@@ -513,7 +674,7 @@
             "staffing" : "command,command,staff,staff",
             "ship-class" : "Sovereign Class",
             "icons" : "tng-icon",
-            "lore" : "One of several Starfleet designs introduced in the 2370s, the Sovereign-class starship would become the Federation’s primary deep-space exploration vessel.",
+            "lore" : "One of several Starfleet designs introduced in the 2370s, the Sovereign-class starship would become the Federation's primary deep-space exploration vessel.",
             "range" : 9,
             "weapons" : 9,
             "shields" : 9,

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -1105,6 +1105,10 @@ export async function fetchImage(url) {
             newUrl = url.replace("https://www.trekcc.org/1e/cardimages/", "https://trekcc.dev/1e/images/imgp.php?src=")
             newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp"
         }
+        if (url.startsWith("https://www.trekcc.org/2e/cardimages/")) {
+            newUrl = url.replace("https://www.trekcc.org/2e/cardimages/", "https://trekcc.dev/2e/images/imgp.php?src=")
+            newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp"
+        }
         else {
             newUrl = url;
         }

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/communication.js
@@ -1102,12 +1102,12 @@ export async function fetchImage(url) {
         // Long term we should update the .json files to the intended host.
         let newUrl;
         if (url.startsWith("https://www.trekcc.org/1e/cardimages/")) {
-            newUrl = url.replace("https://www.trekcc.org/1e/cardimages/", "https://trekcc.dev/1e/images/imgp.php?src=")
-            newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp"
+            newUrl = url.replace("https://www.trekcc.org/1e/cardimages/", "https://trekcc.dev/1e/images/imgp.php?src=");
+            newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp";
         }
-        if (url.startsWith("https://www.trekcc.org/2e/cardimages/")) {
-            newUrl = url.replace("https://www.trekcc.org/2e/cardimages/", "https://trekcc.dev/2e/images/imgp.php?src=")
-            newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp"
+        else if (url.startsWith("https://www.trekcc.org/2e/cardimages/")) {
+            newUrl = url.replace("https://www.trekcc.org/2e/cardimages/", "https://trekcc.dev/2e/images/imgp.php?src=");
+            newUrl = newUrl + "&w=330&q=100&sharpen&sa=webp";
         }
         else {
             newUrl = url;

--- a/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/jCards.js
+++ b/gemp-module/gemp-stccg-client/src/main/web/js/gemp-022/jCards.js
@@ -255,6 +255,8 @@ export default class Card {
         return false;
     }
 
+    // 2026-06-25: I think this is leftover LotR code and it's making its way into some of the 2E cards,
+    //             namely 001_162, 017_066, and 017_087.
     remadeErratas = {
         "0": [7],
         "1": [3, 12, 43, 46, 55, 109, 113, 138, 162, 211, 235, 263, 309, 318, 331, 338, 343, 360],

--- a/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/SkillName.java
+++ b/gemp-module/gemp-stccg-common/src/main/java/com/gempukku/stccg/common/filterable/SkillName.java
@@ -43,7 +43,8 @@ public enum SkillName implements Filterable {
     ASTROMETRICS("Astrometrics", false),
     PROGRAMMING("Programming", false),
     TELEPATHY("Telepathy", false),
-    TRANSPORTERS("Transporters", false);
+    TRANSPORTERS("Transporters", false),
+    INTELLIGENCE("Intelligence", false);
 
     private final String _humanReadable;
 

--- a/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
+++ b/gemp-module/gemp-stccg-logic/src/main/java/com/gempukku/stccg/formats/DefaultGameFormat.java
@@ -9,12 +9,17 @@ import com.gempukku.stccg.common.SetDefinition;
 import com.gempukku.stccg.common.filterable.GameType;
 import com.gempukku.stccg.common.filterable.SubDeck;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 @JsonPropertyOrder({ "gameType", "code", "name", "order", "discardPileIsPublic", "playtest", "minimumDrawDeckSize",
         "maximumSeedDeckSize", "missions", "maximumSameName", "hall"
 })
 public class DefaultGameFormat implements GameFormat {
+
+    private static final Logger LOGGER = LogManager.getLogger(DefaultGameFormat.class);
 
     private static final int DEFAULT_MAX_VALUE = 999;
     private static final int DEFAULT_MIN_VALUE = 0;
@@ -89,7 +94,7 @@ public class DefaultGameFormat implements GameFormat {
                 Enum.valueOf(GameType.class, gameType.toUpperCase().replaceAll("[ '\\-.]", "_"));
         for (SetDefinition set : blueprintLibrary.getSetDefinitions().values()) {
             if (set.getGameType() == _gameType && !excludedSets.contains(set.getSetId())) {
-                addValidSet(Integer.parseInt(set.getSetId()));
+                addValidSet(set.getSetId());
             }
         }
         if (!bannedCards.isEmpty()) {
@@ -135,7 +140,18 @@ public class DefaultGameFormat implements GameFormat {
         sets.put("disabled", "disabled");
         Map<String, SetDefinition> librarySets = library.getSetDefinitions();
         for (String setId : _validSets) {
-            sets.put(setId, librarySets.get(setId).getSetName());
+            if (librarySets.containsKey(setId)) {
+                SetDefinition theSet = librarySets.get(setId);
+                if (theSet != null) {
+                    sets.put(setId, librarySets.get(setId).getSetName());
+                }
+                else {
+                    LOGGER.error("DefaultGameFormat.getValidSetsAndTheirCards(): CardBlueprintLibrary set id {} was null", setId);    
+                }
+            }
+            else {
+                LOGGER.error("DefaultGameFormat.getValidSetsAndTheirCards: CardBlueprintLibrary did not contain set id: {}", setId);
+            }
         }
         return sets;
     }
@@ -206,8 +222,8 @@ public class DefaultGameFormat implements GameFormat {
             _validCards.add(baseBlueprintId);
     }
 
-    private void addValidSet(int setNo) {
-        _validSets.add(String.valueOf(setNo));
+    private void addValidSet(String setNo) {
+        _validSets.add(setNo);
     }
 
     //Additional Hobbit Draft card lists
@@ -223,21 +239,23 @@ public class DefaultGameFormat implements GameFormat {
         _restrictedCardNames.add(cardName);
     }
 
-    private void addErrataSet(CardBlueprintLibrary library, int setID) throws InvalidPropertiesFormatException {
+    // 2026-06-26: I think this logic is leftover from LotR code and does not apply to our sets.
+    private void addErrataSet(CardBlueprintLibrary library, String setID) throws InvalidPropertiesFormatException {
         //Valid errata sets:
         // 50-69 are live errata versions of sets 0-19
         // 70-89 are playtest errata versions of sets 0-19
         // 150-199 are playtest versions of sets V0-V49
-        if(setID < 50 || (setID >= 90 && setID <= 149) || setID > 199)
-            throw new InvalidPropertiesFormatException("Errata sets must be 50-69, 70-89, or 150-159.  Received: " + setID);
+        int setIdAsInt = Integer.parseInt(setID);
+        if(setIdAsInt < 50 || (setIdAsInt >= 90 && setIdAsInt <= 149) || setIdAsInt > 199)
+            throw new InvalidPropertiesFormatException("Errata sets must be 50-69, 70-89, or 150-159.  Received: " + setIdAsInt);
 
         //maps 69 to 19, and also 151 to 101
-        int ogSet = setID - 50;
+        int ogSet = setIdAsInt - 50;
         //playtest sets are offset by 20 more
-        if(setID >= 70 && setID <=89)
-            ogSet = setID - 70;
+        if(setIdAsInt >= 70 && setIdAsInt <=89)
+            ogSet = setIdAsInt - 70;
 
-        var cards = library.getBaseCards().keySet().stream().filter(x -> x.startsWith(String.valueOf(setID))).toList();
+        var cards = library.getBaseCards().keySet().stream().filter(x -> x.startsWith(setID)).toList();
         for(String errataBP : cards) {
             String cardID = errataBP.split("_")[1];
 

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/async/GempHttpRequest.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/async/GempHttpRequest.java
@@ -242,6 +242,7 @@ public class GempHttpRequest {
             UriRequestHandler newHandler = mapper.convertValue(parameters, UriRequestHandler.class);
             newHandler.handleRequest(this, _responseWriter);
         } catch (IllegalArgumentException exp) {
+            LOGGER.error("IllegalArgumentException in handleServerRequest:", exp);
             if (exp.getCause() instanceof InvalidTypeIdException) {
                 // InvalidTypeIdException thrown if initial path not recognized by the Json deserializer
                 logHttpError(uri,

--- a/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/async/handler/decks/GetSetsRequestHandler.java
+++ b/gemp-module/gemp-stccg-server/src/main/java/com/gempukku/stccg/async/handler/decks/GetSetsRequestHandler.java
@@ -32,12 +32,15 @@ public class GetSetsRequestHandler extends DeckRequestHandler implements UriRequ
     }
 
     @Override
-    public final void handleRequest(GempHttpRequest request, ResponseWriter responseWriter)
-            throws Exception {
-        Object[] output = _sets.entrySet().stream()
-                .map(x -> new JSONData.ItemStub(x.getKey(), x.getValue()))
-                .toArray();
-        responseWriter.writeJsonResponse(_jsonMapper.writeValueAsString(output));
+    public final void handleRequest(GempHttpRequest request, ResponseWriter responseWriter) throws Exception {
+        try {
+            Object[] output = _sets.entrySet().stream()
+                    .map(x -> new JSONData.ItemStub(x.getKey(), x.getValue()))
+                    .toArray();
+            responseWriter.writeJsonResponse(_jsonMapper.writeValueAsString(output));
+        } catch (Exception exp) {
+            throw new RuntimeException("Can't load set", exp);
+        }
     }
 
 }


### PR DESCRIPTION
### Summary
simplegarak-commits wants to work on 2E; the first step is being able to create 2E decks with 2E cards via the deck builder. This begins work on re-enabling that.

**Benefits**
* Fixes a null pointer exception (#329) that causes 2E cards not to load in the deck builder. This was caused by storing the set ID in the JSON as a string, then in a couple places trying to parse that as an Int, which stripped off leading zeroes, then trying to load the string IDs again which no longer matched.
* Adds the TrekCC.dev workaround for loading card graphics off the website.
* Adds simplegarak-commits' first pass at adding more basic 2E cards (just plain skill dots) to the set definitions.

**Possible Improvements to this PR**
- ~~Looks like 2E graphics aren't loading from TrekCC.dev even with the workaround, need to talk to JeBuS about getting another CORS exception for the 2E cards.~~  Fixed with the help of JeBuS.
- There's a red errata bar over some of the 2E graphics. I'm pretty sure that's not something we want to keep, since we'll always be showing the latest cards with errata on them, but removal of that will have effects across the card graphics system so that'll be its own PR.